### PR TITLE
Updating gonum/matrix/mat64 dependency to gonum/gonum/mat

### DIFF
--- a/benchmarks_test.go
+++ b/benchmarks_test.go
@@ -3,7 +3,7 @@ package sparse
 import (
 	"testing"
 
-	"github.com/gonum/gonum/mat"
+	"gonum.org/v1/gonum/mat"
 )
 
 type MatMultiplyer interface {

--- a/benchmarks_test.go
+++ b/benchmarks_test.go
@@ -3,75 +3,75 @@ package sparse
 import (
 	"testing"
 
-	"github.com/gonum/matrix/mat64"
+	"github.com/gonum/gonum/mat"
 )
 
 type MatMultiplyer interface {
-	Mul(a, b mat64.Matrix)
+	Mul(a, b mat.Matrix)
 }
 
-func benchmarkMatrixMultiplication(target MatMultiplyer, lhs mat64.Matrix, rhs mat64.Matrix, b *testing.B) {
+func benchmarkMatrixMultiplication(target MatMultiplyer, lhs mat.Matrix, rhs mat.Matrix, b *testing.B) {
 	for n := 0; n < b.N; n++ {
 		target.Mul(lhs, rhs)
 	}
 }
 
 func BenchmarkMulSmallDenseDenseDense(b *testing.B) {
-	t := mat64.NewDense(0, 0, nil)
+	t := mat.NewDense(0, 0, nil)
 	lhs := Random(DenseFormat, 5, 6, 0.4)
 	rhs := Random(DenseFormat, 6, 5, 0.4)
 	benchmarkMatrixMultiplication(t, lhs, rhs, b)
 }
 func BenchmarkMulSmallDenseDOKDense(b *testing.B) {
-	t := mat64.NewDense(0, 0, nil)
+	t := mat.NewDense(0, 0, nil)
 	lhs := Random(DOKFormat, 5, 6, 0.4)
 	rhs := Random(DenseFormat, 6, 5, 0.4)
 	benchmarkMatrixMultiplication(t, lhs, rhs, b)
 }
 func BenchmarkMulSmallDenseDOKDOK(b *testing.B) {
-	t := mat64.NewDense(0, 0, nil)
+	t := mat.NewDense(0, 0, nil)
 	lhs := Random(DOKFormat, 5, 6, 0.4)
 	rhs := Random(DOKFormat, 6, 5, 0.4)
 	benchmarkMatrixMultiplication(t, lhs, rhs, b)
 }
 func BenchmarkMulSmallDenseDenseDOK(b *testing.B) {
-	t := mat64.NewDense(0, 0, nil)
+	t := mat.NewDense(0, 0, nil)
 	lhs := Random(DenseFormat, 5, 6, 0.4)
 	rhs := Random(DOKFormat, 6, 5, 0.4)
 	benchmarkMatrixMultiplication(t, lhs, rhs, b)
 }
 func BenchmarkMulSmallDenseCSRDense(b *testing.B) {
-	t := mat64.NewDense(0, 0, nil)
+	t := mat.NewDense(0, 0, nil)
 	lhs := Random(CSRFormat, 5, 6, 0.4)
 	rhs := Random(DenseFormat, 6, 5, 0.4)
 	benchmarkMatrixMultiplication(t, lhs, rhs, b)
 }
 func BenchmarkMulSmallDenseDenseCSR(b *testing.B) {
-	t := mat64.NewDense(0, 0, nil)
+	t := mat.NewDense(0, 0, nil)
 	lhs := Random(CSRFormat, 5, 6, 0.4)
 	rhs := Random(DenseFormat, 6, 5, 0.4)
 	benchmarkMatrixMultiplication(t, lhs, rhs, b)
 }
 func BenchmarkMulSmallDenseCSRCSR(b *testing.B) {
-	t := mat64.NewDense(0, 0, nil)
+	t := mat.NewDense(0, 0, nil)
 	lhs := Random(CSRFormat, 5, 6, 0.4)
 	rhs := Random(CSRFormat, 6, 5, 0.4)
 	benchmarkMatrixMultiplication(t, lhs, rhs, b)
 }
 func BenchmarkMulSmallDenseCOODense(b *testing.B) {
-	t := mat64.NewDense(0, 0, nil)
+	t := mat.NewDense(0, 0, nil)
 	lhs := Random(COOFormat, 5, 6, 0.4)
 	rhs := Random(DenseFormat, 6, 5, 0.4)
 	benchmarkMatrixMultiplication(t, lhs, rhs, b)
 }
 func BenchmarkMulSmallDenseDenseCOO(b *testing.B) {
-	t := mat64.NewDense(0, 0, nil)
+	t := mat.NewDense(0, 0, nil)
 	lhs := Random(COOFormat, 5, 6, 0.4)
 	rhs := Random(DenseFormat, 6, 5, 0.4)
 	benchmarkMatrixMultiplication(t, lhs, rhs, b)
 }
 func BenchmarkMulSmallDenseCOOCOO(b *testing.B) {
-	t := mat64.NewDense(0, 0, nil)
+	t := mat.NewDense(0, 0, nil)
 	lhs := Random(COOFormat, 5, 6, 0.4)
 	rhs := Random(COOFormat, 6, 5, 0.4)
 	benchmarkMatrixMultiplication(t, lhs, rhs, b)
@@ -121,49 +121,49 @@ func BenchmarkMulSmallCSRCSRCSR(b *testing.B) {
 }
 
 func BenchmarkMulLargeDenseDenseDense(b *testing.B) {
-	t := mat64.NewDense(0, 0, nil)
+	t := mat.NewDense(0, 0, nil)
 	lhs := Random(DenseFormat, 500, 600, 0.01)
 	rhs := Random(DenseFormat, 600, 500, 0.01)
 	benchmarkMatrixMultiplication(t, lhs, rhs, b)
 }
 func BenchmarkMulLargeDenseDOKDense(b *testing.B) {
-	t := mat64.NewDense(0, 0, nil)
+	t := mat.NewDense(0, 0, nil)
 	lhs := Random(DOKFormat, 500, 600, 0.01)
 	rhs := Random(DenseFormat, 600, 500, 0.01)
 	benchmarkMatrixMultiplication(t, lhs, rhs, b)
 }
 func BenchmarkMulLargeDenseDOKDOK(b *testing.B) {
-	t := mat64.NewDense(0, 0, nil)
+	t := mat.NewDense(0, 0, nil)
 	lhs := Random(DOKFormat, 500, 600, 0.01)
 	rhs := Random(DOKFormat, 600, 500, 0.01)
 	benchmarkMatrixMultiplication(t, lhs, rhs, b)
 }
 func BenchmarkMulLargeDenseDenseDOK(b *testing.B) {
-	t := mat64.NewDense(0, 0, nil)
+	t := mat.NewDense(0, 0, nil)
 	lhs := Random(DenseFormat, 500, 600, 0.01)
 	rhs := Random(DOKFormat, 600, 500, 0.01)
 	benchmarkMatrixMultiplication(t, lhs, rhs, b)
 }
 func BenchmarkMulLargeDenseCSRDense(b *testing.B) {
-	t := mat64.NewDense(0, 0, nil)
+	t := mat.NewDense(0, 0, nil)
 	lhs := Random(CSRFormat, 500, 600, 0.01)
 	rhs := Random(DenseFormat, 600, 500, 0.01)
 	benchmarkMatrixMultiplication(t, lhs, rhs, b)
 }
 func BenchmarkMulLargeDenseDenseCSR(b *testing.B) {
-	t := mat64.NewDense(0, 0, nil)
+	t := mat.NewDense(0, 0, nil)
 	lhs := Random(DenseFormat, 500, 600, 0.01)
 	rhs := Random(CSRFormat, 600, 500, 0.01)
 	benchmarkMatrixMultiplication(t, lhs, rhs, b)
 }
 func BenchmarkMulLargeDenseCSRCSR(b *testing.B) {
-	t := mat64.NewDense(0, 0, nil)
+	t := mat.NewDense(0, 0, nil)
 	lhs := Random(CSRFormat, 500, 600, 0.01)
 	rhs := Random(CSRFormat, 600, 500, 0.01)
 	benchmarkMatrixMultiplication(t, lhs, rhs, b)
 }
 func BenchmarkMulLargeDenseCOODense(b *testing.B) {
-	t := mat64.NewDense(0, 0, nil)
+	t := mat.NewDense(0, 0, nil)
 	lhs := Random(COOFormat, 500, 600, 0.01)
 	rhs := Random(DenseFormat, 600, 500, 0.01)
 	benchmarkMatrixMultiplication(t, lhs, rhs, b)
@@ -171,14 +171,14 @@ func BenchmarkMulLargeDenseCOODense(b *testing.B) {
 
 /*
 func BenchmarkMulLargeDenseDenseCOO(b *testing.B) {
-	t := mat64.NewDense(0, 0, nil)
+	t := mat.NewDense(0, 0, nil)
 	lhs := Random(DenseFormat, 500, 600, 0.01)
 	rhs := Random(COOFormat, 600, 500, 0.01)
 	benchmarkMatrixMultiplication(t, lhs, rhs, b)
 }
 */
 //func BenchmarkMulLargeDenseCOOCOO(b *testing.B) {
-//	t := mat64.NewDense(0, 0, nil)
+//	t := mat.NewDense(0, 0, nil)
 //	lhs := createMatrix(CreateCOO, 500, 600, 0.4)
 //	rhs := createMatrix(CreateCOO, 600, 500, 0.4)
 //	benchmarkMatrixMultiplication(t, lhs, rhs, b)
@@ -278,7 +278,7 @@ func BenchmarkAddLargeDenserCSRDenseCSR(b *testing.B) {
 	benchmarkMatrixAddition(t, lhs, rhs, b)
 }
 
-func benchmarkMatrixAddition(target *CSR, lhs mat64.Matrix, rhs mat64.Matrix, b *testing.B) {
+func benchmarkMatrixAddition(target *CSR, lhs mat.Matrix, rhs mat.Matrix, b *testing.B) {
 	for n := 0; n < b.N; n++ {
 		target.Add(lhs, rhs)
 	}

--- a/compressed.go
+++ b/compressed.go
@@ -1,7 +1,7 @@
 package sparse
 
 import (
-	"github.com/gonum/gonum/mat"
+	"gonum.org/v1/gonum/mat"
 )
 
 // compressedSparse represents the common structure for representing compressed sparse
@@ -327,16 +327,16 @@ func (c *CSR) RowNNZ(i int) int {
 
 // RowView slices the Compressed Sparse Row matrix along its primary axis.
 // Returns a Vector containing a copy of elements of row i.
-func (c *CSR) RowView(i int) *mat.Vector {
-	return mat.NewVector(c.j, c.nativeSlice(i))
+func (c *CSR) RowView(i int) *mat.VecDense {
+	return mat.NewVecDense(c.j, c.nativeSlice(i))
 }
 
 // ColView slices the Compressed Sparse Row matrix along its secondary axis.
 // Returns a Vector containing a copy of elements of column j.  ColView
 // is much slower than RowView for CSR matrices so if multiple ColView calls
 // are required, consider first converting to a CSC matrix.
-func (c *CSR) ColView(j int) *mat.Vector {
-	return mat.NewVector(c.i, c.foreignSlice(j))
+func (c *CSR) ColView(j int) *mat.VecDense {
+	return mat.NewVecDense(c.i, c.foreignSlice(j))
 }
 
 // RawRowView returns a slice representing row i of the matrix.  This is a copy
@@ -493,14 +493,14 @@ func (c *CSC) ToType(matType MatrixType) mat.Matrix {
 // Returns a Vector containing a copy of elements of row i.  RowView
 // is much slower than ColView for CSC matrices so if multiple RowView calls
 // are required, consider first converting to a CSR matrix.
-func (c *CSC) RowView(i int) *mat.Vector {
-	return mat.NewVector(c.i, c.foreignSlice(i))
+func (c *CSC) RowView(i int) *mat.VecDense {
+	return mat.NewVecDense(c.i, c.foreignSlice(i))
 }
 
 // ColView slices the Compressed Sparse Column matrix along its primary axis.
 // Returns a Vector containing a copy of elements of column i.
-func (c *CSC) ColView(j int) *mat.Vector {
-	return mat.NewVector(c.j, c.nativeSlice(j))
+func (c *CSC) ColView(j int) *mat.VecDense {
+	return mat.NewVecDense(c.j, c.nativeSlice(j))
 }
 
 // RawRowView returns a slice representing row i of the matrix.  This is a copy

--- a/compressed.go
+++ b/compressed.go
@@ -1,8 +1,7 @@
 package sparse
 
 import (
-	"github.com/gonum/matrix"
-	"github.com/gonum/matrix/mat64"
+	"github.com/gonum/gonum/mat"
 )
 
 // compressedSparse represents the common structure for representing compressed sparse
@@ -24,10 +23,10 @@ func (c *compressedSparse) NNZ() int {
 // and columns or columns and rows respectively.
 func (c *compressedSparse) at(i, j int) float64 {
 	if uint(i) < 0 || uint(i) >= uint(c.i) {
-		panic(matrix.ErrRowAccess)
+		panic(mat.ErrRowAccess)
 	}
 	if uint(j) < 0 || uint(j) >= uint(c.j) {
-		panic(matrix.ErrColAccess)
+		panic(mat.ErrColAccess)
 	}
 
 	// todo: consider a binary search if we can assume the data is ordered within row (CSR)/column (CSC).
@@ -44,10 +43,10 @@ func (c *compressedSparse) at(i, j int) float64 {
 // matrices
 func (c *compressedSparse) set(i, j int, v float64) {
 	if uint(i) < 0 || uint(i) >= uint(c.i) {
-		panic(matrix.ErrRowAccess)
+		panic(mat.ErrRowAccess)
 	}
 	if uint(j) < 0 || uint(j) >= uint(c.j) {
-		panic(matrix.ErrColAccess)
+		panic(mat.ErrColAccess)
 	}
 
 	if v == 0 {
@@ -97,7 +96,7 @@ func (c *compressedSparse) insert(i int, j int, v float64, insertionPoint int) {
 // efficient than a foreign slice which must scan for each slice element.
 func (c *compressedSparse) nativeSlice(i int) []float64 {
 	if i >= c.i || i < 0 {
-		panic(matrix.ErrRowAccess)
+		panic(mat.ErrRowAccess)
 	}
 
 	slice := make([]float64, c.j)
@@ -117,7 +116,7 @@ func (c *compressedSparse) nativeSlice(i int) []float64 {
 // can be used instead.
 func (c *compressedSparse) foreignSlice(j int) []float64 {
 	if j >= c.j || j < 0 {
-		panic(matrix.ErrColAccess)
+		panic(mat.ErrColAccess)
 	}
 
 	slice := make([]float64, c.i)
@@ -164,9 +163,9 @@ func (c *compressedSparse) UnmarshalBinaryFrom(r io.Reader) (int, error) {
 //
 // It should be clear that CSR is like CSC except the slices are row major order rather than column major and
 // CSC is essentially the transpose of a CSR.
-// As this type implements the gonum mat64.Matrix interface, it may be used with any of the Gonum mat64
+// As this type implements the gonum mat.Matrix interface, it may be used with any of the Gonum mat
 // functions that accept Matrix types as parameters in place of other matrix types included in the Gonum
-// mat64 package e.g. mat64.Dense.
+// mat package e.g. mat.Dense.
 type CSR struct {
 	compressedSparse
 }
@@ -179,10 +178,10 @@ type CSR struct {
 // and vice versa.
 func NewCSR(r int, c int, ia []int, ja []int, data []float64) *CSR {
 	if uint(r) < 0 {
-		panic(matrix.ErrRowAccess)
+		panic(mat.ErrRowAccess)
 	}
 	if uint(c) < 0 {
-		panic(matrix.ErrColAccess)
+		panic(mat.ErrColAccess)
 	}
 
 	return &CSR{
@@ -214,12 +213,12 @@ func (c *CSR) Set(m, n int, v float64) {
 
 // T transposes the matrix creating a new CSC matrix sharing the same backing data storage but switching
 // column and row sizes and index & index pointer slices i.e. rows become columns and columns become rows.
-func (c *CSR) T() mat64.Matrix {
+func (c *CSR) T() mat.Matrix {
 	return NewCSC(c.j, c.i, c.indptr, c.ind, c.data)
 }
 
 // Clone copies the specified matrix into the receiver
-func (c *CSR) Clone(b mat64.Matrix) {
+func (c *CSR) Clone(b mat.Matrix) {
 	c.i, c.j = b.Dims()
 
 	c.indptr = make([]int, c.i+1)
@@ -240,7 +239,7 @@ func (c *CSR) Clone(b mat64.Matrix) {
 }
 
 // Copy copies the receiver into a new CSR matrix
-func (c *CSR) Copy() mat64.Matrix {
+func (c *CSR) Copy() mat.Matrix {
 	i, j := c.i, c.j
 	indptr := make([]int, len(c.indptr))
 	ind := make([]int, len(c.ind))
@@ -253,10 +252,10 @@ func (c *CSR) Copy() mat64.Matrix {
 	return NewCSR(i, j, indptr, ind, data)
 }
 
-// ToDense returns a mat64.Dense dense format version of the matrix.  The returned mat64.Dense
+// ToDense returns a mat.Dense dense format version of the matrix.  The returned mat.Dense
 // matrix will not share underlying storage with the receiver nor is the receiver modified by this call.
-func (c *CSR) ToDense() *mat64.Dense {
-	mat := mat64.NewDense(c.i, c.j, nil)
+func (c *CSR) ToDense() *mat.Dense {
+	mat := mat.NewDense(c.i, c.j, nil)
 
 	for i := 0; i < len(c.indptr)-1; i++ {
 		for j := c.indptr[i]; j < c.indptr[i+1]; j++ {
@@ -314,30 +313,30 @@ func (c *CSR) ToCSC() *CSC {
 }
 
 // ToType returns an alternative format version fo the matrix in the format specified.
-func (c *CSR) ToType(matType MatrixType) mat64.Matrix {
+func (c *CSR) ToType(matType MatrixType) mat.Matrix {
 	return matType.Convert(c)
 }
 
 // RowNNZ returns the Number of Non Zero values in the specified row i.  RowNNZ will panic if i is out of range.
 func (c *CSR) RowNNZ(i int) int {
 	if uint(i) < 0 || uint(i) >= uint(c.i) {
-		panic(matrix.ErrRowAccess)
+		panic(mat.ErrRowAccess)
 	}
 	return c.indptr[i+1] - c.indptr[i]
 }
 
 // RowView slices the Compressed Sparse Row matrix along its primary axis.
 // Returns a Vector containing a copy of elements of row i.
-func (c *CSR) RowView(i int) *mat64.Vector {
-	return mat64.NewVector(c.j, c.nativeSlice(i))
+func (c *CSR) RowView(i int) *mat.Vector {
+	return mat.NewVector(c.j, c.nativeSlice(i))
 }
 
 // ColView slices the Compressed Sparse Row matrix along its secondary axis.
 // Returns a Vector containing a copy of elements of column j.  ColView
 // is much slower than RowView for CSR matrices so if multiple ColView calls
 // are required, consider first converting to a CSC matrix.
-func (c *CSR) ColView(j int) *mat64.Vector {
-	return mat64.NewVector(c.i, c.foreignSlice(j))
+func (c *CSR) ColView(j int) *mat.Vector {
+	return mat.NewVector(c.i, c.foreignSlice(j))
 }
 
 // RawRowView returns a slice representing row i of the matrix.  This is a copy
@@ -371,9 +370,9 @@ func (c *CSR) RawColView(j int) []float64 {
 //
 // It should be clear that CSC is like CSR except the slices are column major order rather than row major and CSC
 // is essentially the transpose of a CSR.
-// As this type implements the gonum mat64.Matrix interface, it may be used with any of the Gonum mat64 functions
-// that accept Matrix types as parameters in place of other matrix types included in the Gonum mat64 package
-// e.g. mat64.Dense.
+// As this type implements the gonum mat.Matrix interface, it may be used with any of the Gonum mat functions
+// that accept Matrix types as parameters in place of other matrix types included in the Gonum mat package
+// e.g. mat.Dense.
 type CSC struct {
 	compressedSparse
 }
@@ -386,10 +385,10 @@ type CSC struct {
 // and vice versa.
 func NewCSC(r int, c int, indptr []int, ind []int, data []float64) *CSC {
 	if uint(r) < 0 {
-		panic(matrix.ErrRowAccess)
+		panic(mat.ErrRowAccess)
 	}
 	if uint(c) < 0 {
-		panic(matrix.ErrColAccess)
+		panic(mat.ErrColAccess)
 	}
 
 	return &CSC{
@@ -421,14 +420,14 @@ func (c *CSC) Set(m, n int, v float64) {
 
 // T transposes the matrix creating a new CSR matrix sharing the same backing data storage but switching
 // column and row sizes and index & index pointer slices i.e. rows become columns and columns become rows.
-func (c *CSC) T() mat64.Matrix {
+func (c *CSC) T() mat.Matrix {
 	return NewCSR(c.i, c.j, c.indptr, c.ind, c.data)
 }
 
-// ToDense returns a mat64.Dense dense format version of the matrix.  The returned mat64.Dense
+// ToDense returns a mat.Dense dense format version of the matrix.  The returned mat.Dense
 // matrix will not share underlying storage with the receiver nor is the receiver modified by this call.
-func (c *CSC) ToDense() *mat64.Dense {
-	mat := mat64.NewDense(c.j, c.i, nil)
+func (c *CSC) ToDense() *mat.Dense {
+	mat := mat.NewDense(c.j, c.i, nil)
 
 	for i := 0; i < len(c.indptr)-1; i++ {
 		for j := c.indptr[i]; j < c.indptr[i+1]; j++ {
@@ -486,7 +485,7 @@ func (c *CSC) ToCSC() *CSC {
 }
 
 // ToType returns an alternative format version fo the matrix in the format specified.
-func (c *CSC) ToType(matType MatrixType) mat64.Matrix {
+func (c *CSC) ToType(matType MatrixType) mat.Matrix {
 	return matType.Convert(c)
 }
 
@@ -494,14 +493,14 @@ func (c *CSC) ToType(matType MatrixType) mat64.Matrix {
 // Returns a Vector containing a copy of elements of row i.  RowView
 // is much slower than ColView for CSC matrices so if multiple RowView calls
 // are required, consider first converting to a CSR matrix.
-func (c *CSC) RowView(i int) *mat64.Vector {
-	return mat64.NewVector(c.i, c.foreignSlice(i))
+func (c *CSC) RowView(i int) *mat.Vector {
+	return mat.NewVector(c.i, c.foreignSlice(i))
 }
 
 // ColView slices the Compressed Sparse Column matrix along its primary axis.
 // Returns a Vector containing a copy of elements of column i.
-func (c *CSC) ColView(j int) *mat64.Vector {
-	return mat64.NewVector(c.j, c.nativeSlice(j))
+func (c *CSC) ColView(j int) *mat.Vector {
+	return mat.NewVector(c.j, c.nativeSlice(j))
 }
 
 // RawRowView returns a slice representing row i of the matrix.  This is a copy

--- a/compressed_arith.go
+++ b/compressed_arith.go
@@ -1,7 +1,7 @@
 package sparse
 
 import (
-	"github.com/gonum/gonum/mat"
+	"gonum.org/v1/gonum/mat"
 )
 
 // Mul takes the matrix product (Dot product) of the supplied matrices a and b and stores the result

--- a/compressed_arith.go
+++ b/compressed_arith.go
@@ -1,18 +1,17 @@
 package sparse
 
 import (
-	"github.com/gonum/matrix"
-	"github.com/gonum/matrix/mat64"
+	"github.com/gonum/gonum/mat"
 )
 
 // Mul takes the matrix product (Dot product) of the supplied matrices a and b and stores the result
 // in the receiver.  If the number of columns does not equal the number of rows in b, Mul will panic.
-func (c *CSR) Mul(a, b mat64.Matrix) {
+func (c *CSR) Mul(a, b mat.Matrix) {
 	ar, ac := a.Dims()
 	br, bc := b.Dims()
 
 	if ac != br {
-		panic(matrix.ErrShape)
+		panic(mat.ErrShape)
 	}
 
 	if dia, ok := a.(*DIA); ok {
@@ -40,7 +39,7 @@ func (c *CSR) Mul(a, b mat64.Matrix) {
 			c.mulCSRCSC(lhs, rhs)
 			return
 		}
-		// handle case where matrix A is CSR (matrix B can be any implementation of mat64.Matrix)
+		// handle case where matrix A is CSR (matrix B can be any implementation of mat.Matrix)
 		for i := 0; i < ar; i++ {
 			c.indptr[i] = t
 			for j := 0; j < bc; j++ {
@@ -58,7 +57,7 @@ func (c *CSR) Mul(a, b mat64.Matrix) {
 			}
 		}
 	} else {
-		// handle any implementation of mat64.Matrix for both matrix A and B
+		// handle any implementation of mat.Matrix for both matrix A and B
 		row := make([]float64, ac)
 		for i := 0; i < ar; i++ {
 			c.indptr[i] = t
@@ -125,7 +124,7 @@ func (c *CSR) mulCSRCSC(lhs *CSR, rhs *CSC) {
 // in the receiver.  This method caters for the specialised case of multiplying by a diagonal matrix where
 // significant optimisation is possible due to the sparsity pattern of the matrix.  If trans is true, the method
 // will assume that other was the LHS (Left Hand Side) operand and that dia was the RHS.
-func (c *CSR) mulDIA(dia *DIA, other mat64.Matrix, trans bool) {
+func (c *CSR) mulDIA(dia *DIA, other mat.Matrix, trans bool) {
 	var csMat compressedSparse
 	isCS := false
 
@@ -185,12 +184,12 @@ func (c *CSR) mulDIA(dia *DIA, other mat64.Matrix, trans bool) {
 
 // Add adds matrices a and b together and stores the result in the receiver.
 // If matrices a and b are not the same shape then the method will panic.
-func (c *CSR) Add(a, b mat64.Matrix) {
+func (c *CSR) Add(a, b mat.Matrix) {
 	ar, ac := a.Dims()
 	br, bc := b.Dims()
 
 	if ar != br || ac != bc {
-		panic(matrix.ErrShape)
+		panic(mat.ErrShape)
 	}
 
 	lCsr, lIsCsr := a.(*CSR)
@@ -218,9 +217,9 @@ func (c *CSR) Add(a, b mat64.Matrix) {
 
 }
 
-// addCSR adds a CSR matrix to any implementation of mat64.Matrix and stores the
+// addCSR adds a CSR matrix to any implementation of mat.Matrix and stores the
 // result in the receiver.
-func (c *CSR) addCSR(csr *CSR, other mat64.Matrix) {
+func (c *CSR) addCSR(csr *CSR, other mat.Matrix) {
 	c.i, c.j = csr.Dims()
 	c.indptr = make([]int, c.i+1)
 

--- a/compressed_arith_test.go
+++ b/compressed_arith_test.go
@@ -3,7 +3,7 @@ package sparse
 import (
 	"testing"
 
-	"github.com/gonum/matrix/mat64"
+	"github.com/gonum/gonum/mat"
 )
 
 func TestCSRMul(t *testing.T) {
@@ -258,7 +258,7 @@ func TestCSRMul(t *testing.T) {
 	for ti, test := range tests {
 		t.Logf("**** Test Run %d.\n", ti+1)
 
-		expected := mat64.NewDense(test.cm, test.cn, test.cdata)
+		expected := mat.NewDense(test.cm, test.cn, test.cdata)
 
 		a := test.atype(test.am, test.an, test.adata)
 		b := test.btype(test.bm, test.bn, test.bdata)
@@ -266,8 +266,8 @@ func TestCSRMul(t *testing.T) {
 		csr := NewCSR(0, 0, nil, nil, nil)
 		csr.Mul(a, b)
 
-		if !mat64.Equal(expected, csr) {
-			t.Logf("Expected:\n%v\n but received:\n%v\n", mat64.Formatted(expected), mat64.Formatted(csr))
+		if !mat.Equal(expected, csr) {
+			t.Logf("Expected:\n%v\n but received:\n%v\n", mat.Formatted(expected), mat.Formatted(csr))
 			t.Fail()
 		}
 	}
@@ -389,7 +389,7 @@ func TestCSRAdd(t *testing.T) {
 	for ti, test := range tests {
 		t.Logf("**** Test Run %d.\n", ti+1)
 
-		expected := mat64.NewDense(test.cm, test.cn, test.cdata)
+		expected := mat.NewDense(test.cm, test.cn, test.cdata)
 
 		a := test.atype(test.am, test.an, test.adata)
 		b := test.btype(test.bm, test.bn, test.bdata)
@@ -397,8 +397,8 @@ func TestCSRAdd(t *testing.T) {
 		csr := NewCSR(0, 0, nil, nil, nil)
 		csr.Add(a, b)
 
-		if !mat64.Equal(expected, csr) {
-			t.Logf("Expected:\n%v\n but received:\n%v\n", mat64.Formatted(expected), mat64.Formatted(csr))
+		if !mat.Equal(expected, csr) {
+			t.Logf("Expected:\n%v\n but received:\n%v\n", mat.Formatted(expected), mat.Formatted(csr))
 			t.Fail()
 		}
 	}

--- a/compressed_arith_test.go
+++ b/compressed_arith_test.go
@@ -3,7 +3,7 @@ package sparse
 import (
 	"testing"
 
-	"github.com/gonum/gonum/mat"
+	"gonum.org/v1/gonum/mat"
 )
 
 func TestCSRMul(t *testing.T) {

--- a/compressed_test.go
+++ b/compressed_test.go
@@ -3,7 +3,7 @@ package sparse
 import (
 	"testing"
 
-	"github.com/gonum/gonum/mat"
+	"gonum.org/v1/gonum/mat"
 )
 
 func TestCSRCSCTranspose(t *testing.T) {

--- a/compressed_test.go
+++ b/compressed_test.go
@@ -3,7 +3,7 @@ package sparse
 import (
 	"testing"
 
-	"github.com/gonum/matrix/mat64"
+	"github.com/gonum/gonum/mat"
 )
 
 func TestCSRCSCTranspose(t *testing.T) {
@@ -33,7 +33,7 @@ func TestCSRCSCTranspose(t *testing.T) {
 	for ti, test := range tests {
 		t.Logf("**** Test Run %d.\n", ti+1)
 
-		expected := mat64.NewDense(test.er, test.ec, test.result)
+		expected := mat.NewDense(test.er, test.ec, test.result)
 
 		csr := CreateCSR(test.r, test.c, test.data).(*CSR)
 		csc := CreateCSC(test.r, test.c, test.data).(*CSC)
@@ -41,14 +41,14 @@ func TestCSRCSCTranspose(t *testing.T) {
 		t.Logf("CSR: r: %d, c: %d, ind: %v, indptr: %v, data: %v", csr.i, csr.j, csr.ind, csr.indptr, csr.data)
 		t.Logf("CSC: r: %d, c: %d, ind: %v, indptr: %v, data: %v", csc.i, csc.j, csc.ind, csc.indptr, csc.data)
 
-		if !mat64.Equal(expected, csr.T()) {
-			t.Logf("CSR is:\n%v\n", mat64.Formatted(csr))
-			t.Logf("For CSR^T, Expected:\n%v\n but received:\n%v\n", mat64.Formatted(expected), mat64.Formatted(csr.T()))
+		if !mat.Equal(expected, csr.T()) {
+			t.Logf("CSR is:\n%v\n", mat.Formatted(csr))
+			t.Logf("For CSR^T, Expected:\n%v\n but received:\n%v\n", mat.Formatted(expected), mat.Formatted(csr.T()))
 			t.Fail()
 		}
-		if !mat64.Equal(expected, csc.T()) {
-			t.Logf("CSC is:\n%v\n", mat64.Formatted(csc))
-			t.Logf("For CSC^T, Expected:\n%v\n but received:\n%v\n", mat64.Formatted(expected), mat64.Formatted(csc.T()))
+		if !mat.Equal(expected, csc.T()) {
+			t.Logf("CSC is:\n%v\n", mat.Formatted(csc))
+			t.Logf("For CSC^T, Expected:\n%v\n but received:\n%v\n", mat.Formatted(expected), mat.Formatted(csc.T()))
 			t.Fail()
 		}
 	}
@@ -102,7 +102,7 @@ func TestCSRCSCConversion(t *testing.T) {
 	for ti, test := range tests {
 		t.Logf("**** Test Run %d. %s\n", ti+1, test.desc)
 
-		d := mat64.NewDense(r, c, data)
+		d := mat.NewDense(r, c, data)
 
 		a := test.create(r, c, data)
 		sa, ok := a.(Sparser)
@@ -111,10 +111,10 @@ func TestCSRCSCConversion(t *testing.T) {
 		}
 		b := test.convert(sa.(TypeConverter))
 
-		if !mat64.Equal(d, b) {
+		if !mat.Equal(d, b) {
 			t.Logf("d : %v\n", a)
 			t.Logf("B : %v\n", b)
-			t.Logf("Expected:\n%v\n but received:\n%v\n", mat64.Formatted(d), mat64.Formatted(b))
+			t.Logf("Expected:\n%v\n but received:\n%v\n", mat.Formatted(d), mat.Formatted(b))
 			t.Fail()
 		}
 	}
@@ -238,7 +238,7 @@ func TestCSRCSCSet(t *testing.T) {
 	for ti, test := range tests {
 		t.Logf("**** Test Run %d.\n", ti+1)
 
-		expected := mat64.NewDense(test.r, test.c, test.result)
+		expected := mat.NewDense(test.r, test.c, test.result)
 
 		csr := CreateCSR(test.r, test.c, test.data).(*CSR)
 		csc := CreateCSC(test.r, test.c, test.data).(*CSC)
@@ -252,12 +252,12 @@ func TestCSRCSCSet(t *testing.T) {
 		t.Logf("CSR: r: %d, c: %d, ind: %v, indptr: %v, data: %v", csr.i, csr.j, csr.ind, csr.indptr, csr.data)
 		t.Logf("CSC: r: %d, c: %d, ind: %v, indptr: %v, data: %v", csc.i, csc.j, csc.ind, csc.indptr, csc.data)
 
-		if !mat64.Equal(expected, csr) {
-			t.Logf("For CSR.Set(), Expected:\n%v\n but received:\n%v\n", mat64.Formatted(expected), mat64.Formatted(csr))
+		if !mat.Equal(expected, csr) {
+			t.Logf("For CSR.Set(), Expected:\n%v\n but received:\n%v\n", mat.Formatted(expected), mat.Formatted(csr))
 			t.Fail()
 		}
-		if !mat64.Equal(expected, csc) {
-			t.Logf("For CSC.Set(), Expected:\n%v\n but received:\n%v\n", mat64.Formatted(expected), mat64.Formatted(csc))
+		if !mat.Equal(expected, csc) {
+			t.Logf("For CSC.Set(), Expected:\n%v\n but received:\n%v\n", mat.Formatted(expected), mat.Formatted(csc))
 			t.Fail()
 		}
 	}
@@ -289,7 +289,7 @@ func TestCSRCSCRowColView(t *testing.T) {
 	for ti, test := range tests {
 		t.Logf("**** Test Run %d.\n", ti+1)
 
-		dense := mat64.NewDense(test.r, test.c, test.data)
+		dense := mat.NewDense(test.r, test.c, test.data)
 		csr := CreateCSR(test.r, test.c, test.data).(*CSR)
 		csc := CreateCSC(test.r, test.c, test.data).(*CSC)
 
@@ -298,11 +298,11 @@ func TestCSRCSCRowColView(t *testing.T) {
 			row1 := csc.RowView(i)
 			for k := 0; k < row.Len(); k++ {
 				if row.At(k, 0) != test.data[i*test.c+k] {
-					t.Logf("ROW: Vector = \n%v\nElement %d = %f was not element %d, %d from \n%v\n", mat64.Formatted(row), k, row.At(k, 0), i, k, mat64.Formatted(dense))
+					t.Logf("ROW: Vector = \n%v\nElement %d = %f was not element %d, %d from \n%v\n", mat.Formatted(row), k, row.At(k, 0), i, k, mat.Formatted(dense))
 					t.Fail()
 				}
 				if row1.At(k, 0) != test.data[i*test.c+k] {
-					t.Logf("ROW: Vector = \n%v\nElement %d = %f was not element %d, %d from \n%v\n", mat64.Formatted(row1), k, row1.At(k, 0), i, k, mat64.Formatted(dense))
+					t.Logf("ROW: Vector = \n%v\nElement %d = %f was not element %d, %d from \n%v\n", mat.Formatted(row1), k, row1.At(k, 0), i, k, mat.Formatted(dense))
 					t.Fail()
 				}
 			}
@@ -313,11 +313,11 @@ func TestCSRCSCRowColView(t *testing.T) {
 			col1 := csc.ColView(j)
 			for k := 0; k < col.Len(); k++ {
 				if col.At(k, 0) != test.data[k*test.c+j] {
-					t.Logf("COL: Vector = \n%v\nElement %d = %f was not element %d, %d from \n%v\n", mat64.Formatted(col), k, col.At(k, 0), k, j, mat64.Formatted(dense))
+					t.Logf("COL: Vector = \n%v\nElement %d = %f was not element %d, %d from \n%v\n", mat.Formatted(col), k, col.At(k, 0), k, j, mat.Formatted(dense))
 					t.Fail()
 				}
 				if col1.At(k, 0) != test.data[k*test.c+j] {
-					t.Logf("COL: Vector = \n%v\nElement %d = %f was not element %d, %d from \n%v\n", mat64.Formatted(col1), k, col1.At(k, 0), k, j, mat64.Formatted(dense))
+					t.Logf("COL: Vector = \n%v\nElement %d = %f was not element %d, %d from \n%v\n", mat.Formatted(col1), k, col1.At(k, 0), k, j, mat.Formatted(dense))
 					t.Fail()
 				}
 			}

--- a/coordinate.go
+++ b/coordinate.go
@@ -3,16 +3,15 @@ package sparse
 import (
 	"sort"
 
-	"github.com/gonum/matrix"
-	"github.com/gonum/matrix/mat64"
+	"github.com/gonum/gonum/mat"
 )
 
 // COO is a COOrdinate format sparse matrix implementation (sometimes called `Tiplet` format) and implements the
 // Matrix interface from gonum/matrix.  This allows large sparse (mostly zero values) matrices to be stored
 // efficiently in memory (only storing non-zero values).  COO matrices are good for constructing sparse matrices
 // incrementally and very good at converting to CSR and CSC formats but poor for arithmetic operations.  As this
-// type implements the gonum mat64.Matrix interface, it may be used with any of the Gonum mat64 functions that
-// accept Matrix types as parameters in place of other matrix types included in the Gonum mat64 package e.g. mat64.Dense.
+// type implements the gonum mat.Matrix interface, it may be used with any of the Gonum mat functions that
+// accept Matrix types as parameters in place of other matrix types included in the Gonum mat package e.g. mat.Dense.
 type COO struct {
 	r             int
 	c             int
@@ -31,10 +30,10 @@ type COO struct {
 // and vice versa.
 func NewCOO(r int, c int, rows []int, cols []int, data []float64) *COO {
 	if uint(r) < 0 {
-		panic(matrix.ErrRowAccess)
+		panic(mat.ErrRowAccess)
 	}
 	if uint(c) < 0 {
-		panic(matrix.ErrColAccess)
+		panic(mat.ErrColAccess)
 	}
 
 	coo := &COO{r: r, c: c}
@@ -47,7 +46,7 @@ func NewCOO(r int, c int, rows []int, cols []int, data []float64) *COO {
 
 			coo.Canonicalise()
 		} else {
-			panic(matrix.ErrRowAccess)
+			panic(mat.ErrRowAccess)
 		}
 	}
 
@@ -69,10 +68,10 @@ func (c *COO) Dims() (int, int) {
 // duplicate values will be summed together.
 func (c *COO) At(i, j int) float64 {
 	if uint(i) < 0 || uint(i) >= uint(c.r) {
-		panic(matrix.ErrRowAccess)
+		panic(mat.ErrRowAccess)
 	}
 	if uint(j) < 0 || uint(j) >= uint(c.c) {
-		panic(matrix.ErrColAccess)
+		panic(mat.ErrColAccess)
 	}
 
 	result := 0.0
@@ -91,7 +90,7 @@ func (c *COO) At(i, j int) float64 {
 
 // T transposes the matrix creating a new COO matrix sharing the same backing data but switching
 // column and row sizes and index slices i.e. rows become columns and columns become rows.
-func (c *COO) T() mat64.Matrix {
+func (c *COO) T() mat.Matrix {
 	return NewCOO(c.c, c.r, c.cols, c.rows, c.data)
 }
 
@@ -100,10 +99,10 @@ func (c *COO) T() mat64.Matrix {
 // are allowed.
 func (c *COO) Set(i, j int, v float64) {
 	if uint(i) < 0 || uint(i) >= uint(c.r) {
-		panic(matrix.ErrRowAccess)
+		panic(mat.ErrRowAccess)
 	}
 	if uint(j) < 0 || uint(j) >= uint(c.c) {
-		panic(matrix.ErrColAccess)
+		panic(mat.ErrColAccess)
 	}
 
 	c.rows = append(c.rows, i)
@@ -181,14 +180,14 @@ func (c *COO) isColMajorOrdered(i, j int) bool {
 	return false
 }
 
-// ToDense returns a mat64.Dense dense format version of the matrix.  The returned mat64.Dense
+// ToDense returns a mat.Dense dense format version of the matrix.  The returned mat.Dense
 // matrix will not share underlying storage with the receiver. nor is the receiver modified by this call
-func (c *COO) ToDense() *mat64.Dense {
+func (c *COO) ToDense() *mat.Dense {
 	if !c.canonicalised {
 		c.Canonicalise()
 	}
 
-	mat := mat64.NewDense(c.r, c.c, nil)
+	mat := mat.NewDense(c.r, c.c, nil)
 	for i := 0; i < len(c.data); i++ {
 		mat.Set(c.rows[i], c.cols[i], c.data[i])
 	}
@@ -271,20 +270,20 @@ func (c *COO) ToCSC() *CSC {
 }
 
 // ToType returns an alternative format version fo the matrix in the format specified.
-func (c *COO) ToType(matType MatrixType) mat64.Matrix {
+func (c *COO) ToType(matType MatrixType) mat.Matrix {
 	return matType.Convert(c)
 }
 
 // RowView slices the matrix and returns a Vector containing a copy of elements
 // of row i.
-func (c *COO) RowView(i int) *mat64.Vector {
-	return mat64.NewVector(c.c, c.RawRowView(i))
+func (c *COO) RowView(i int) *mat.Vector {
+	return mat.NewVector(c.c, c.RawRowView(i))
 }
 
 // ColView slices the matrix and returns a Vector containing a copy of elements
 // of column i.
-func (c *COO) ColView(j int) *mat64.Vector {
-	return mat64.NewVector(c.r, c.RawColView(j))
+func (c *COO) ColView(j int) *mat.Vector {
+	return mat.NewVector(c.r, c.RawColView(j))
 }
 
 // RawRowView returns a slice representing row i of the matrix.  This is a copy

--- a/coordinate.go
+++ b/coordinate.go
@@ -3,7 +3,7 @@ package sparse
 import (
 	"sort"
 
-	"github.com/gonum/gonum/mat"
+	"gonum.org/v1/gonum/mat"
 )
 
 // COO is a COOrdinate format sparse matrix implementation (sometimes called `Tiplet` format) and implements the
@@ -276,14 +276,14 @@ func (c *COO) ToType(matType MatrixType) mat.Matrix {
 
 // RowView slices the matrix and returns a Vector containing a copy of elements
 // of row i.
-func (c *COO) RowView(i int) *mat.Vector {
-	return mat.NewVector(c.c, c.RawRowView(i))
+func (c *COO) RowView(i int) *mat.VecDense {
+	return mat.NewVecDense(c.c, c.RawRowView(i))
 }
 
 // ColView slices the matrix and returns a Vector containing a copy of elements
 // of column i.
-func (c *COO) ColView(j int) *mat.Vector {
-	return mat.NewVector(c.r, c.RawColView(j))
+func (c *COO) ColView(j int) *mat.VecDense {
+	return mat.NewVecDense(c.r, c.RawColView(j))
 }
 
 // RawRowView returns a slice representing row i of the matrix.  This is a copy

--- a/coordinate_test.go
+++ b/coordinate_test.go
@@ -3,7 +3,7 @@ package sparse
 import (
 	"testing"
 
-	"github.com/gonum/matrix/mat64"
+	"github.com/gonum/gonum/mat"
 )
 
 func TestCOOConversion(t *testing.T) {
@@ -39,13 +39,13 @@ func TestCOOConversion(t *testing.T) {
 	for ti, test := range tests {
 		t.Logf("**** Test Run %d. %s\n", ti+1, test.desc)
 
-		d := mat64.NewDense(r, c, data)
+		d := mat.NewDense(r, c, data)
 
 		a := test.create(r, c, data)
 
-		if !mat64.Equal(d, a) {
+		if !mat.Equal(d, a) {
 			t.Logf("A : %v\n", a)
-			t.Logf("Expected:\n%v\n but created:\n%v\n", mat64.Formatted(d), mat64.Formatted(a))
+			t.Logf("Expected:\n%v\n but created:\n%v\n", mat.Formatted(d), mat.Formatted(a))
 			t.Fail()
 		}
 
@@ -56,10 +56,10 @@ func TestCOOConversion(t *testing.T) {
 
 		b := test.convert(sa.(TypeConverter))
 
-		if !mat64.Equal(a, b) {
+		if !mat.Equal(a, b) {
 			t.Logf("A : %v\n", a)
 			t.Logf("B : %v\n", b)
-			t.Logf("Expected:\n%v\n but received:\n%v\n", mat64.Formatted(a), mat64.Formatted(b))
+			t.Logf("Expected:\n%v\n but received:\n%v\n", mat.Formatted(a), mat.Formatted(b))
 			t.Fail()
 		}
 	}
@@ -91,14 +91,14 @@ func TestCOORowColView(t *testing.T) {
 	for ti, test := range tests {
 		t.Logf("**** Test Run %d.\n", ti+1)
 
-		dense := mat64.NewDense(test.r, test.c, test.data)
+		dense := mat.NewDense(test.r, test.c, test.data)
 		coo := CreateCOO(test.r, test.c, test.data).(*COO)
 
 		for i := 0; i < test.r; i++ {
 			row := coo.RowView(i)
 			for k := 0; k < row.Len(); k++ {
 				if row.At(k, 0) != test.data[i*test.c+k] {
-					t.Logf("ROW: Vector = \n%v\nElement %d = %f was not element %d, %d from \n%v\n", mat64.Formatted(row), k, row.At(k, 0), i, k, mat64.Formatted(dense))
+					t.Logf("ROW: Vector = \n%v\nElement %d = %f was not element %d, %d from \n%v\n", mat.Formatted(row), k, row.At(k, 0), i, k, mat.Formatted(dense))
 					t.Fail()
 				}
 			}
@@ -108,7 +108,7 @@ func TestCOORowColView(t *testing.T) {
 			col := coo.ColView(j)
 			for k := 0; k < col.Len(); k++ {
 				if col.At(k, 0) != test.data[k*test.c+j] {
-					t.Logf("COL: Vector = \n%v\nElement %d = %f was not element %d, %d from \n%v\n", mat64.Formatted(col), k, col.At(k, 0), k, j, mat64.Formatted(dense))
+					t.Logf("COL: Vector = \n%v\nElement %d = %f was not element %d, %d from \n%v\n", mat.Formatted(col), k, col.At(k, 0), k, j, mat.Formatted(dense))
 					t.Fail()
 				}
 			}

--- a/coordinate_test.go
+++ b/coordinate_test.go
@@ -3,7 +3,7 @@ package sparse
 import (
 	"testing"
 
-	"github.com/gonum/gonum/mat"
+	"gonum.org/v1/gonum/mat"
 )
 
 func TestCOOConversion(t *testing.T) {

--- a/diagonal.go
+++ b/diagonal.go
@@ -1,7 +1,7 @@
 package sparse
 
 import (
-	"github.com/gonum/gonum/mat"
+	"gonum.org/v1/gonum/mat"
 )
 
 // DIA matrix type is a specialised matrix designed to store DIAgonal values of square symmetrical
@@ -66,14 +66,14 @@ func (d *DIA) Diagonal() []float64 {
 
 // RowView slices the matrix and returns a Vector containing a copy of elements
 // of row i.
-func (d *DIA) RowView(i int) *mat.Vector {
-	return mat.NewVector(d.m, d.slice(i))
+func (d *DIA) RowView(i int) *mat.VecDense {
+	return mat.NewVecDense(d.m, d.slice(i))
 }
 
 // ColView slices the matrix and returns a Vector containing a copy of elements
 // of column j.
-func (d *DIA) ColView(j int) *mat.Vector {
-	return mat.NewVector(d.m, d.slice(j))
+func (d *DIA) ColView(j int) *mat.VecDense {
+	return mat.NewVecDense(d.m, d.slice(j))
 }
 
 // RawRowView returns a slice representing row i of the matrix.  This is a copy

--- a/diagonal.go
+++ b/diagonal.go
@@ -1,8 +1,7 @@
 package sparse
 
 import (
-	"github.com/gonum/matrix"
-	"github.com/gonum/matrix/mat64"
+	"github.com/gonum/gonum/mat"
 )
 
 // DIA matrix type is a specialised matrix designed to store DIAgonal values of square symmetrical
@@ -20,7 +19,7 @@ type DIA struct {
 // in the matrix.
 func NewDIA(m int, diagonal []float64) *DIA {
 	if uint(m) < 0 || m != len(diagonal) {
-		panic(matrix.ErrRowAccess)
+		panic(mat.ErrRowAccess)
 	}
 
 	return &DIA{m: m, data: diagonal}
@@ -35,10 +34,10 @@ func (d *DIA) Dims() (int, int) {
 // for i or j fall outside the dimensions of the matrix.
 func (d *DIA) At(i, j int) float64 {
 	if uint(i) < 0 || uint(i) >= uint(d.m) {
-		panic(matrix.ErrRowAccess)
+		panic(mat.ErrRowAccess)
 	}
 	if uint(j) < 0 || uint(j) >= uint(d.m) {
-		panic(matrix.ErrColAccess)
+		panic(mat.ErrColAccess)
 	}
 
 	if i == j {
@@ -49,7 +48,7 @@ func (d *DIA) At(i, j int) float64 {
 
 // T returns the matrix transposed.  In the case of a DIA (DIAgonal) sparse matrix this method
 // simply returns the receiver as the matrix is perfectly symmetrical and transposing has no effect.
-func (d *DIA) T() mat64.Matrix {
+func (d *DIA) T() mat.Matrix {
 	return d
 }
 
@@ -67,14 +66,14 @@ func (d *DIA) Diagonal() []float64 {
 
 // RowView slices the matrix and returns a Vector containing a copy of elements
 // of row i.
-func (d *DIA) RowView(i int) *mat64.Vector {
-	return mat64.NewVector(d.m, d.slice(i))
+func (d *DIA) RowView(i int) *mat.Vector {
+	return mat.NewVector(d.m, d.slice(i))
 }
 
 // ColView slices the matrix and returns a Vector containing a copy of elements
 // of column j.
-func (d *DIA) ColView(j int) *mat64.Vector {
-	return mat64.NewVector(d.m, d.slice(j))
+func (d *DIA) ColView(j int) *mat.Vector {
+	return mat.NewVector(d.m, d.slice(j))
 }
 
 // RawRowView returns a slice representing row i of the matrix.  This is a copy
@@ -92,7 +91,7 @@ func (d *DIA) RawColView(j int) []float64 {
 // nativeSlice slices the DIAgonal matrix.
 func (d *DIA) slice(i int) []float64 {
 	if i >= d.m || i < 0 {
-		panic(matrix.ErrRowAccess)
+		panic(mat.ErrRowAccess)
 	}
 
 	slice := make([]float64, d.m)

--- a/diagonal_test.go
+++ b/diagonal_test.go
@@ -3,7 +3,7 @@ package sparse
 import (
 	"testing"
 
-	"github.com/gonum/gonum/mat"
+	"gonum.org/v1/gonum/mat"
 )
 
 func TestDIARowColView(t *testing.T) {

--- a/diagonal_test.go
+++ b/diagonal_test.go
@@ -3,7 +3,7 @@ package sparse
 import (
 	"testing"
 
-	"github.com/gonum/matrix/mat64"
+	"github.com/gonum/gonum/mat"
 )
 
 func TestDIARowColView(t *testing.T) {
@@ -34,14 +34,14 @@ func TestDIARowColView(t *testing.T) {
 	for ti, test := range tests {
 		t.Logf("**** Test Run %d.\n", ti+1)
 
-		dense := mat64.NewDense(test.r, test.c, test.data)
+		dense := mat.NewDense(test.r, test.c, test.data)
 		dia := CreateDIA(test.r, test.c, test.data).(*DIA)
 
 		for i := 0; i < test.r; i++ {
 			row := dia.RowView(i)
 			for k := 0; k < row.Len(); k++ {
 				if row.At(k, 0) != test.data[i*test.c+k] {
-					t.Logf("ROW: Vector = \n%v\nElement %d = %f was not element %d, %d from \n%v\n", mat64.Formatted(row), k, row.At(k, 0), i, k, mat64.Formatted(dense))
+					t.Logf("ROW: Vector = \n%v\nElement %d = %f was not element %d, %d from \n%v\n", mat.Formatted(row), k, row.At(k, 0), i, k, mat.Formatted(dense))
 					t.Fail()
 				}
 			}
@@ -51,7 +51,7 @@ func TestDIARowColView(t *testing.T) {
 			col := dia.ColView(j)
 			for k := 0; k < col.Len(); k++ {
 				if col.At(k, 0) != test.data[k*test.c+j] {
-					t.Logf("COL: Vector = \n%v\nElement %d = %f was not element %d, %d from \n%v\n", mat64.Formatted(col), k, col.At(k, 0), k, j, mat64.Formatted(dense))
+					t.Logf("COL: Vector = \n%v\nElement %d = %f was not element %d, %d from \n%v\n", mat.Formatted(col), k, col.At(k, 0), k, j, mat.Formatted(dense))
 					t.Fail()
 				}
 			}

--- a/dictionaryofkeys.go
+++ b/dictionaryofkeys.go
@@ -1,8 +1,7 @@
 package sparse
 
 import (
-	"github.com/gonum/matrix"
-	"github.com/gonum/matrix/mat64"
+	"github.com/gonum/gonum/mat"
 )
 
 // key is used to specify the row and column of elements within the matrix.
@@ -14,8 +13,8 @@ type key struct {
 // This allows large sparse (mostly zero values) matrices to be stored efficiently in memory (only storing
 // non-zero values).  DOK matrices are good for incrementally constructing sparse matrices but poor for arithmetic
 // operations or other operations that require iterating over elements of the matrix sequentially.  As this type
-// implements the gonum mat64.Matrix interface, it may be used with any of the Gonum mat64 functions that accept
-// Matrix types as parameters in place of other matrix types included in the Gonum mat64 package e.g. mat64.Dense.
+// implements the gonum mat.Matrix interface, it may be used with any of the Gonum mat functions that accept
+// Matrix types as parameters in place of other matrix types included in the Gonum mat package e.g. mat.Dense.
 type DOK struct {
 	r        int
 	c        int
@@ -26,10 +25,10 @@ type DOK struct {
 // dimensions (rows * columns)
 func NewDOK(r, c int) *DOK {
 	if uint(r) < 0 {
-		panic(matrix.ErrRowAccess)
+		panic(mat.ErrRowAccess)
 	}
 	if uint(c) < 0 {
-		panic(matrix.ErrColAccess)
+		panic(mat.ErrColAccess)
 	}
 
 	return &DOK{r: r, c: c, elements: make(map[key]float64)}
@@ -44,28 +43,28 @@ func (d *DOK) Dims() (r, c int) {
 // for i or j fall outside the dimensions of the matrix.
 func (d *DOK) At(i, j int) float64 {
 	if uint(i) < 0 || uint(i) >= uint(d.r) {
-		panic(matrix.ErrRowAccess)
+		panic(mat.ErrRowAccess)
 	}
 	if uint(j) < 0 || uint(j) >= uint(d.c) {
-		panic(matrix.ErrColAccess)
+		panic(mat.ErrColAccess)
 	}
 
 	return d.elements[key{i, j}]
 }
 
-// T transposes the matrix.  This is an implicit transpose, wrapping the matrix in a mat64.Transpose type.
-func (d *DOK) T() mat64.Matrix {
-	return mat64.Transpose{d}
+// T transposes the matrix.  This is an implicit transpose, wrapping the matrix in a mat.Transpose type.
+func (d *DOK) T() mat.Matrix {
+	return mat.Transpose{d}
 }
 
 // Set sets the element of the matrix located at row i and column j to equal the specified value, v.  Set
 // will panic if specified values for i or j fall outside the dimensions of the matrix.
 func (d *DOK) Set(i, j int, v float64) {
 	if uint(i) < 0 || uint(i) >= uint(d.r) {
-		panic(matrix.ErrRowAccess)
+		panic(mat.ErrRowAccess)
 	}
 	if uint(j) < 0 || uint(j) >= uint(d.c) {
-		panic(matrix.ErrColAccess)
+		panic(mat.ErrColAccess)
 	}
 
 	d.elements[key{i, j}] = v
@@ -76,10 +75,10 @@ func (d *DOK) NNZ() int {
 	return len(d.elements)
 }
 
-// ToDense returns a mat64.Dense dense format version of the matrix.  The returned mat64.Dense
+// ToDense returns a mat.Dense dense format version of the matrix.  The returned mat.Dense
 // matrix will not share underlying storage with the receiver nor is the receiver modified by this call.
-func (d *DOK) ToDense() *mat64.Dense {
-	mat := mat64.NewDense(d.r, d.c, nil)
+func (d *DOK) ToDense() *mat.Dense {
+	mat := mat.NewDense(d.r, d.c, nil)
 
 	for k, v := range d.elements {
 		mat.Set(k.i, k.j, v)
@@ -127,20 +126,20 @@ func (d *DOK) ToCSC() *CSC {
 }
 
 // ToType returns an alternative format version fo the matrix in the format specified.
-func (d *DOK) ToType(matType MatrixType) mat64.Matrix {
+func (d *DOK) ToType(matType MatrixType) mat.Matrix {
 	return matType.Convert(d)
 }
 
 // RowView slices the matrix and returns a Vector containing a copy of elements
 // of row i.
-func (d *DOK) RowView(i int) *mat64.Vector {
-	return mat64.NewVector(d.c, d.RawRowView(i))
+func (d *DOK) RowView(i int) *mat.Vector {
+	return mat.NewVector(d.c, d.RawRowView(i))
 }
 
 // ColView slices the matrix and returns a Vector containing a copy of elements
 // of column i.
-func (d *DOK) ColView(j int) *mat64.Vector {
-	return mat64.NewVector(d.r, d.RawColView(j))
+func (d *DOK) ColView(j int) *mat.Vector {
+	return mat.NewVector(d.r, d.RawColView(j))
 }
 
 // RawRowView returns a slice representing row i of the matrix.  This is a copy

--- a/dictionaryofkeys.go
+++ b/dictionaryofkeys.go
@@ -1,7 +1,7 @@
 package sparse
 
 import (
-	"github.com/gonum/gonum/mat"
+	"gonum.org/v1/gonum/mat"
 )
 
 // key is used to specify the row and column of elements within the matrix.
@@ -132,14 +132,14 @@ func (d *DOK) ToType(matType MatrixType) mat.Matrix {
 
 // RowView slices the matrix and returns a Vector containing a copy of elements
 // of row i.
-func (d *DOK) RowView(i int) *mat.Vector {
-	return mat.NewVector(d.c, d.RawRowView(i))
+func (d *DOK) RowView(i int) *mat.VecDense {
+	return mat.NewVecDense(d.c, d.RawRowView(i))
 }
 
 // ColView slices the matrix and returns a Vector containing a copy of elements
 // of column i.
-func (d *DOK) ColView(j int) *mat.Vector {
-	return mat.NewVector(d.r, d.RawColView(j))
+func (d *DOK) ColView(j int) *mat.VecDense {
+	return mat.NewVecDense(d.r, d.RawColView(j))
 }
 
 // RawRowView returns a slice representing row i of the matrix.  This is a copy

--- a/dictionaryofkeys_test.go
+++ b/dictionaryofkeys_test.go
@@ -3,8 +3,7 @@ package sparse
 import (
 	"testing"
 
-	"github.com/gonum/matrix"
-	"github.com/gonum/matrix/mat64"
+	"github.com/gonum/gonum/mat"
 )
 
 func TestDOKConversion(t *testing.T) {
@@ -61,7 +60,7 @@ func TestDOKConversion(t *testing.T) {
 
 	for ti, test := range tests {
 		t.Logf("**** Test Run %d.\n", ti+1)
-		expected := mat64.NewDense(test.m, test.n, test.output)
+		expected := mat.NewDense(test.m, test.n, test.output)
 
 		dok := NewDOK(test.m, test.n)
 		for k, v := range test.data {
@@ -69,18 +68,18 @@ func TestDOKConversion(t *testing.T) {
 		}
 
 		coo := dok.ToCOO()
-		if !(mat64.Equal(expected, coo)) {
-			t.Logf("Expected:\n%v \nbut found COO matrix:\n%v\n", mat64.Formatted(expected), mat64.Formatted(coo))
+		if !(mat.Equal(expected, coo)) {
+			t.Logf("Expected:\n%v \nbut found COO matrix:\n%v\n", mat.Formatted(expected), mat.Formatted(coo))
 		}
 
 		csr := dok.ToCSR()
-		if !(mat64.Equal(expected, csr)) {
-			t.Logf("Expected:\n%v \nbut found CSR matrix:\n%v\n", mat64.Formatted(expected), mat64.Formatted(csr))
+		if !(mat.Equal(expected, csr)) {
+			t.Logf("Expected:\n%v \nbut found CSR matrix:\n%v\n", mat.Formatted(expected), mat.Formatted(csr))
 		}
 
 		csc := dok.ToCSC()
-		if !(mat64.Equal(expected, csc)) {
-			t.Logf("Expected:\n%v \nbut found CSC matrix:\n%v\n", mat64.Formatted(expected), mat64.Formatted(csc))
+		if !(mat.Equal(expected, csc)) {
+			t.Logf("Expected:\n%v \nbut found CSC matrix:\n%v\n", mat.Formatted(expected), mat.Formatted(csc))
 		}
 	}
 
@@ -113,12 +112,12 @@ func TestDOKTranspose(t *testing.T) {
 	for ti, test := range tests {
 		t.Logf("**** Test Run %d.\n", ti+1)
 
-		expected := mat64.NewDense(test.er, test.ec, test.result)
+		expected := mat.NewDense(test.er, test.ec, test.result)
 
 		dok := CreateDOK(test.r, test.c, test.data)
 
-		if !mat64.Equal(expected, dok.T()) {
-			t.Logf("Expected:\n %v\n but received:\n %v\n", mat64.Formatted(expected), mat64.Formatted(dok.T()))
+		if !mat.Equal(expected, dok.T()) {
+			t.Logf("Expected:\n %v\n but received:\n %v\n", mat.Formatted(expected), mat.Formatted(dok.T()))
 		}
 	}
 }
@@ -149,14 +148,14 @@ func TestDOKRowColView(t *testing.T) {
 	for ti, test := range tests {
 		t.Logf("**** Test Run %d.\n", ti+1)
 
-		dense := mat64.NewDense(test.r, test.c, test.data)
+		dense := mat.NewDense(test.r, test.c, test.data)
 		dok := CreateDOK(test.r, test.c, test.data).(*DOK)
 
 		for i := 0; i < test.r; i++ {
 			row := dok.RowView(i)
 			for k := 0; k < row.Len(); k++ {
 				if row.At(k, 0) != test.data[i*test.c+k] {
-					t.Logf("ROW: Vector = \n%v\nElement %d = %f was not element %d, %d from \n%v\n", mat64.Formatted(row), k, row.At(k, 0), i, k, mat64.Formatted(dense))
+					t.Logf("ROW: Vector = \n%v\nElement %d = %f was not element %d, %d from \n%v\n", mat.Formatted(row), k, row.At(k, 0), i, k, mat.Formatted(dense))
 					t.Fail()
 				}
 			}
@@ -166,7 +165,7 @@ func TestDOKRowColView(t *testing.T) {
 			col := dok.ColView(j)
 			for k := 0; k < col.Len(); k++ {
 				if col.At(k, 0) != test.data[k*test.c+j] {
-					t.Logf("COL: Vector = \n%v\nElement %d = %f was not element %d, %d from \n%v\n", mat64.Formatted(col), k, col.At(k, 0), k, j, mat64.Formatted(dense))
+					t.Logf("COL: Vector = \n%v\nElement %d = %f was not element %d, %d from \n%v\n", mat.Formatted(col), k, col.At(k, 0), k, j, mat.Formatted(dense))
 					t.Fail()
 				}
 			}
@@ -174,9 +173,9 @@ func TestDOKRowColView(t *testing.T) {
 	}
 }
 
-type MatrixCreator func(m, n int, data []float64) mat64.Matrix
+type MatrixCreator func(m, n int, data []float64) mat.Matrix
 
-func CreateDOK(m, n int, data []float64) mat64.Matrix {
+func CreateDOK(m, n int, data []float64) mat.Matrix {
 	dok := NewDOK(m, n)
 	if data != nil {
 		for i := 0; i < m; i++ {
@@ -191,21 +190,21 @@ func CreateDOK(m, n int, data []float64) mat64.Matrix {
 	return dok
 }
 
-func CreateCOO(m, n int, data []float64) mat64.Matrix {
+func CreateCOO(m, n int, data []float64) mat.Matrix {
 	return CreateDOK(m, n, data).(*DOK).ToCOO()
 }
 
-func CreateCSR(m, n int, data []float64) mat64.Matrix {
+func CreateCSR(m, n int, data []float64) mat.Matrix {
 	return CreateDOK(m, n, data).(*DOK).ToCSR()
 }
 
-func CreateCSC(m, n int, data []float64) mat64.Matrix {
+func CreateCSC(m, n int, data []float64) mat.Matrix {
 	return CreateDOK(m, n, data).(*DOK).ToCSC()
 }
 
-func CreateDIA(m, n int, data []float64) mat64.Matrix {
+func CreateDIA(m, n int, data []float64) mat.Matrix {
 	if m != n {
-		panic((matrix.ErrRowAccess))
+		panic((mat.ErrRowAccess))
 	}
 	c := make([]float64, m)
 	for i := 0; i < m; i++ {
@@ -214,6 +213,6 @@ func CreateDIA(m, n int, data []float64) mat64.Matrix {
 	return NewDIA(m, c)
 }
 
-func CreateDense(m, n int, data []float64) mat64.Matrix {
-	return mat64.NewDense(m, n, data)
+func CreateDense(m, n int, data []float64) mat.Matrix {
+	return mat.NewDense(m, n, data)
 }

--- a/dictionaryofkeys_test.go
+++ b/dictionaryofkeys_test.go
@@ -3,7 +3,7 @@ package sparse
 import (
 	"testing"
 
-	"github.com/gonum/gonum/mat"
+	"gonum.org/v1/gonum/mat"
 )
 
 func TestDOKConversion(t *testing.T) {

--- a/example_test.go
+++ b/example_test.go
@@ -3,7 +3,7 @@ package sparse
 import (
 	"fmt"
 
-	"github.com/gonum/gonum/mat"
+	"gonum.org/v1/gonum/mat"
 )
 
 func Example() {

--- a/example_test.go
+++ b/example_test.go
@@ -3,7 +3,7 @@ package sparse
 import (
 	"fmt"
 
-	"github.com/gonum/matrix/mat64"
+	"github.com/gonum/gonum/mat"
 )
 
 func Example() {
@@ -14,7 +14,7 @@ func Example() {
 	dokMatrix.Set(0, 0, 5)
 	dokMatrix.Set(2, 1, 7)
 
-	// Demonstrate accessing values (could use mat64.Formatted() to
+	// Demonstrate accessing values (could use mat.Formatted() to
 	// pretty print but this demonstrates element access)
 	m, n := dokMatrix.Dims()
 	for i := 0; i < m; i++ {
@@ -27,13 +27,13 @@ func Example() {
 		fmt.Printf("\n")
 	}
 
-	// Convert DOK matrix to mat64.Dense just for fun
+	// Convert DOK matrix to mat.Dense just for fun
 	// (not required for upcoming multiplication operation)
 	denseMatrix := dokMatrix.ToDense()
 
 	// Confirm the two matrices in different formats are equal
-	// Using the mat64.Equal function
-	if !mat64.Equal(dokMatrix, denseMatrix) {
+	// Using the mat.Equal function
+	if !mat.Equal(dokMatrix, denseMatrix) {
 		fmt.Println("DOK and converted Dense are not equal")
 	}
 

--- a/matrix.go
+++ b/matrix.go
@@ -3,14 +3,13 @@ package sparse
 import (
 	"math/rand"
 
-	"github.com/gonum/matrix"
-	"github.com/gonum/matrix/mat64"
+	"github.com/gonum/gonum/mat"
 )
 
-// Sparser is the interface for Sparse matrices.  Sparser contains the mat64.Matrix interface so automatically
-// exposes all mat64.Matrix methods.
+// Sparser is the interface for Sparse matrices.  Sparser contains the mat.Matrix interface so automatically
+// exposes all mat.Matrix methods.
 type Sparser interface {
-	mat64.Matrix
+	mat.Matrix
 
 	// NNZ returns the Number of Non Zero elements in the sparse matrix.
 	NNZ() int
@@ -18,8 +17,8 @@ type Sparser interface {
 
 // TypeConverter interface for converting to other matrix formats
 type TypeConverter interface {
-	// ToDense returns a mat64.Dense dense format version of the matrix.
-	ToDense() *mat64.Dense
+	// ToDense returns a mat.Dense dense format version of the matrix.
+	ToDense() *mat.Dense
 
 	// ToDOK returns a Dictionary Of Keys (DOK) sparse format version of the matrix.
 	ToDOK() *DOK
@@ -34,20 +33,20 @@ type TypeConverter interface {
 	ToCSC() *CSC
 
 	// ToType returns an alternative format version fo the matrix in the format specified.
-	ToType(matType MatrixType) mat64.Matrix
+	ToType(matType MatrixType) mat.Matrix
 }
 
 // MatrixType represents a type of Matrix format.  This is used to specify target format types for conversion, etc.
 type MatrixType interface {
 	// Convert converts to the type of matrix format represented by the receiver from the specified TypeConverter.
-	Convert(from TypeConverter) mat64.Matrix
+	Convert(from TypeConverter) mat.Matrix
 }
 
-// DenseType represents the mat64.Dense matrix type format
+// DenseType represents the mat.Dense matrix type format
 type DenseType int
 
-// Convert converts the specified TypeConverter to mat64.Dense format
-func (d DenseType) Convert(from TypeConverter) mat64.Matrix {
+// Convert converts the specified TypeConverter to mat.Dense format
+func (d DenseType) Convert(from TypeConverter) mat.Matrix {
 	return from.ToDense()
 }
 
@@ -55,7 +54,7 @@ func (d DenseType) Convert(from TypeConverter) mat64.Matrix {
 type DOKType int
 
 // Convert converts the specified TypeConverter to DOK (Dictionary of Keys) format
-func (s DOKType) Convert(from TypeConverter) mat64.Matrix {
+func (s DOKType) Convert(from TypeConverter) mat.Matrix {
 	return from.ToDOK()
 }
 
@@ -63,7 +62,7 @@ func (s DOKType) Convert(from TypeConverter) mat64.Matrix {
 type COOType int
 
 // Convert converts the specified TypeConverter to COOrdinate format
-func (s COOType) Convert(from TypeConverter) mat64.Matrix {
+func (s COOType) Convert(from TypeConverter) mat.Matrix {
 	return from.ToCOO()
 }
 
@@ -71,7 +70,7 @@ func (s COOType) Convert(from TypeConverter) mat64.Matrix {
 type CSRType int
 
 // Convert converts the specified TypeConverter to CSR (Compressed Sparse Row) format
-func (s CSRType) Convert(from TypeConverter) mat64.Matrix {
+func (s CSRType) Convert(from TypeConverter) mat.Matrix {
 	return from.ToCSR()
 }
 
@@ -79,7 +78,7 @@ func (s CSRType) Convert(from TypeConverter) mat64.Matrix {
 type CSCType int
 
 // Convert converts the specified TypeConverter to CSC (Compressed Sparse Column) format
-func (s CSCType) Convert(from TypeConverter) mat64.Matrix {
+func (s CSCType) Convert(from TypeConverter) mat.Matrix {
 	return from.ToCSC()
 }
 
@@ -106,7 +105,7 @@ const (
 // of non zero values.  Density is a value between 0 and 1 (0 >= density >= 1) where a density
 // of 1 will construct a matrix entirely composed of non zero values and a density of 0 will
 // have only zero values.
-func Random(t MatrixType, r int, c int, density float32) mat64.Matrix {
+func Random(t MatrixType, r int, c int, density float32) mat.Matrix {
 	d := int(density * float32(r) * float32(c))
 
 	m := make([]int, d)
@@ -124,11 +123,11 @@ func Random(t MatrixType, r int, c int, density float32) mat64.Matrix {
 
 // RawRowView returns a slice representing row i of the matrix.  This is a copy
 // of the data within the matrix and does not share underlying storage.
-func rawRowView(m mat64.Matrix, i int) []float64 {
+func rawRowView(m mat.Matrix, i int) []float64 {
 	r, c := m.Dims()
 
 	if i >= r || i < 0 {
-		panic(matrix.ErrRowAccess)
+		panic(mat.ErrRowAccess)
 	}
 
 	slice := make([]float64, c)
@@ -142,11 +141,11 @@ func rawRowView(m mat64.Matrix, i int) []float64 {
 
 // RawColView returns a slice representing col i of the matrix.  This is a copy
 // of the data within the matrix and does not share underlying storage.
-func rawColView(m mat64.Matrix, j int) []float64 {
+func rawColView(m mat.Matrix, j int) []float64 {
 	r, c := m.Dims()
 
 	if j >= c || j < 0 {
-		panic(matrix.ErrColAccess)
+		panic(mat.ErrColAccess)
 	}
 
 	slice := make([]float64, r)

--- a/matrix.go
+++ b/matrix.go
@@ -3,7 +3,7 @@ package sparse
 import (
 	"math/rand"
 
-	"github.com/gonum/gonum/mat"
+	"gonum.org/v1/gonum/mat"
 )
 
 // Sparser is the interface for Sparse matrices.  Sparser contains the mat.Matrix interface so automatically


### PR DESCRIPTION
Interested in using this implementation for sparse linear algebra! Noticed that the current underlying matrix type is deprecated, so I went ahead and updated to the current gonum standard.