### PR TITLE
ENH: added a MatVec(CSR, []float64) routine

### DIFF
--- a/compressed_arith.go
+++ b/compressed_arith.go
@@ -88,6 +88,26 @@ func (c *CSR) Mul(a, b mat.Matrix) {
 	c.indptr[c.i] = t
 }
 
+// MatVec computes the matrix vector product between lhs and rhs and stores
+// the result in out
+func MatVec(lhs *CSR, rhs []float64, out []float64) {
+	m, n := lhs.Dims()
+	if len(rhs) != n {
+		panic(mat.ErrShape)
+	}
+	if len(out) != m {
+		panic(mat.ErrShape)
+	}
+
+	for row := 0; row < m; row++ {
+		val := 0.0
+		for colind := lhs.indptr[row]; colind < lhs.indptr[row+1]; colind++ {
+			val += lhs.data[colind] * rhs[lhs.ind[colind]]
+		}
+		out[row] = val
+	}
+}
+
 // mulCSRCSC handles special case of matrix multiplication (dot product) where the LHS matrix
 // (A) is CSR format and the RHS matrix (B) is CSC format.
 func (c *CSR) mulCSRCSC(lhs *CSR, rhs *CSC) {

--- a/compressed_arith.go
+++ b/compressed_arith.go
@@ -88,9 +88,9 @@ func (c *CSR) Mul(a, b mat.Matrix) {
 	c.indptr[c.i] = t
 }
 
-// MatVec computes the matrix vector product between lhs and rhs and stores
+// MulMatRawVec computes the matrix vector product between lhs and rhs and stores
 // the result in out
-func MatVec(lhs *CSR, rhs []float64, out []float64) {
+func MulMatRawVec(lhs *CSR, rhs []float64, out []float64) {
 	m, n := lhs.Dims()
 	if len(rhs) != n {
 		panic(mat.ErrShape)

--- a/compressed_arith_test.go
+++ b/compressed_arith_test.go
@@ -398,7 +398,7 @@ func TestCSRMatVec(t *testing.T) {
 		t.Logf("**** Test Run %d.\n", ti+1)
 		lhs := NewCSR(test.am, test.an, test.aindptr, test.aind, test.adata)
 		have := make([]float64, test.am)
-		MatVec(lhs, test.rhs, have)
+		MulMatRawVec(lhs, test.rhs, have)
 
 		for row := 0; row < test.am; row++ {
 			// NOTE: can only use precision 1e-11 b/c of printing output in numpy


### PR DESCRIPTION
This adds a  CSR matrix times vector routine. I use `[]float64` for both the right hand side and the output of the function.



