### PR TITLE
add binany marshal / unmarshal for COO, DOK, CSC, CSR

### DIFF
--- a/persistence.go
+++ b/persistence.go
@@ -19,6 +19,14 @@ var (
 
 	_ encoding.BinaryMarshaler   = (*DIA)(nil)
 	_ encoding.BinaryUnmarshaler = (*DIA)(nil)
+	_ encoding.BinaryMarshaler   = (*COO)(nil)
+	_ encoding.BinaryUnmarshaler = (*COO)(nil)
+	_ encoding.BinaryMarshaler   = (*DOK)(nil)
+	_ encoding.BinaryUnmarshaler = (*DOK)(nil)
+	_ encoding.BinaryMarshaler   = (*CSC)(nil)
+	_ encoding.BinaryUnmarshaler = (*CSC)(nil)
+	_ encoding.BinaryMarshaler   = (*CSR)(nil)
+	_ encoding.BinaryUnmarshaler = (*CSR)(nil)
 )
 
 // MarshalBinary binary serialises the receiver into a []byte and returns the result.
@@ -191,6 +199,1089 @@ func (m *DIA) UnmarshalBinaryFrom(r io.Reader) (int, error) {
 		m.data[i] = math.Float64frombits(binary.LittleEndian.Uint64(buf[:]))
 	}
 
+	return n, nil
+}
+
+// MarshalBinary binary serialises the receiver into a []byte and returns the result.
+//
+// SparseMatrix is little-endian encoded as follows:
+//   0 -  7  number of rows    (int64)
+//   8 - 15  number of columns (int64)
+//  16 - 23  number of indptr  (int64)
+//  24 - 31  number of ind     (int64)
+//  32 - 39  number of non zero elements (int64)
+//  40 - ..  data elements for indptr, ind, and data (float64)
+func (c *CSR) MarshalBinary() ([]byte, error) {
+	bufLen := 5*int64(sizeInt64) + // row and column count plus lengths of the slices
+		int64(len(c.matrix.Indptr))*int64(sizeInt64) + // indptr slice
+		int64(len(c.matrix.Ind))*int64(sizeInt64) + // ind slice
+		int64(len(c.matrix.Data))*int64(sizeFloat64) // data slice
+	if bufLen <= 0 {
+		// bufLen is too big and has wrapped around.
+		return nil, errors.New("sparse: buffer for data is too big")
+	}
+
+	p := 0
+	buf := make([]byte, bufLen)
+	binary.LittleEndian.PutUint64(buf[p:p+sizeInt64], uint64(c.matrix.I))
+	p += sizeInt64
+	binary.LittleEndian.PutUint64(buf[p:p+sizeInt64], uint64(c.matrix.J))
+	p += sizeInt64
+	binary.LittleEndian.PutUint64(buf[p:p+sizeInt64], uint64(len(c.matrix.Indptr)))
+	p += sizeInt64
+	binary.LittleEndian.PutUint64(buf[p:p+sizeInt64], uint64(len(c.matrix.Ind)))
+	p += sizeInt64
+	binary.LittleEndian.PutUint64(buf[p:p+sizeInt64], uint64(len(c.matrix.Data)))
+	p += sizeInt64
+
+	for _, x := range c.matrix.Indptr {
+		binary.LittleEndian.PutUint64(buf[p:p+sizeInt64], uint64(x))
+		p += sizeInt64
+	}
+
+	for _, x := range c.matrix.Ind {
+		binary.LittleEndian.PutUint64(buf[p:p+sizeInt64], uint64(x))
+		p += sizeInt64
+	}
+
+	for _, x := range c.matrix.Data {
+		binary.LittleEndian.PutUint64(buf[p:p+sizeFloat64], math.Float64bits(x))
+		p += sizeFloat64
+	}
+
+	return buf, nil
+}
+
+// MarshalBinaryTo binary serialises the receiver and writes it into w.
+// MarshalBinaryTo returns the number of bytes written into w and an error, if any.
+//
+// See MarshalBinary for the serialised layout.
+func (c *CSR) MarshalBinaryTo(w io.Writer) (int, error) {
+	var n int
+	var buf [8]byte
+	binary.LittleEndian.PutUint64(buf[:], uint64(c.matrix.I))
+	nn, err := w.Write(buf[:])
+	n += nn
+	if err != nil {
+		return n, err
+	}
+	binary.LittleEndian.PutUint64(buf[:], uint64(c.matrix.J))
+	nn, err = w.Write(buf[:])
+	n += nn
+	if err != nil {
+		return n, err
+	}
+	binary.LittleEndian.PutUint64(buf[:], uint64(len(c.matrix.Indptr)))
+	nn, err = w.Write(buf[:])
+	n += nn
+	if err != nil {
+		return n, err
+	}
+	binary.LittleEndian.PutUint64(buf[:], uint64(len(c.matrix.Ind)))
+	nn, err = w.Write(buf[:])
+	n += nn
+	if err != nil {
+		return n, err
+	}
+	binary.LittleEndian.PutUint64(buf[:], uint64(len(c.matrix.Data)))
+	nn, err = w.Write(buf[:])
+	n += nn
+	if err != nil {
+		return n, err
+	}
+
+	for _, x := range c.matrix.Indptr {
+		binary.LittleEndian.PutUint64(buf[:], uint64(x))
+		nn, err = w.Write(buf[:])
+		n += nn
+		if err != nil {
+			return n, err
+		}
+	}
+
+	for _, x := range c.matrix.Ind {
+		binary.LittleEndian.PutUint64(buf[:], uint64(x))
+		nn, err = w.Write(buf[:])
+		n += nn
+		if err != nil {
+			return n, err
+		}
+	}
+
+	for _, x := range c.matrix.Data {
+		binary.LittleEndian.PutUint64(buf[:], math.Float64bits(x))
+		nn, err = w.Write(buf[:])
+		n += nn
+		if err != nil {
+			return n, err
+		}
+	}
+
+	return n, nil
+}
+
+// UnmarshalBinary binary deserialises the []byte into the receiver.
+// It panics if the receiver is a non-zero DIA matrix.
+//
+// See MarshalBinary for the on-disk layout.
+//
+// Limited checks on the validity of the binary input are performed:
+//  - an error is returned if the resulting compressed sprase matrix is too
+//  big for the current architecture (e.g. a 16GB matrix written by a
+//  64b application and read back from a 32b application.)
+// UnmarshalBinary does not limit the size of the unmarshaled matrix, and so
+// it should not be used on untrusted data.
+func (c *CSR) UnmarshalBinary(data []byte) error {
+	if len(data) < 5*sizeInt64 {
+		return errors.New("sparse: data is missing required attributes")
+	}
+
+	p := 0
+	c.matrix.I = int(binary.LittleEndian.Uint64(data[p : p+sizeInt64]))
+	p += sizeInt64
+	c.matrix.J = int(binary.LittleEndian.Uint64(data[p : p+sizeInt64]))
+	p += sizeInt64
+	pn := int64(binary.LittleEndian.Uint64(data[p : p+sizeInt64]))
+	p += sizeInt64
+	pi := int64(binary.LittleEndian.Uint64(data[p : p+sizeInt64]))
+	p += sizeInt64
+	pd := int64(binary.LittleEndian.Uint64(data[p : p+sizeInt64]))
+	p += sizeInt64
+
+	// if int(nnz) < 0 || nnz > maxLen {
+	// 	return errors.New("sparse: data is too big")
+	// }
+	// if r < 0 || c < 0 || r < nnz || c < nnz {
+	// 	return errors.New("sparse: dimensions/data size mismatch")
+	// }
+	// if len(data) != int(nnz)*sizeFloat64+3*sizeInt64 {
+	// 	return errors.New("sparse: data/buffer size mismatch")
+	// }
+
+	c.matrix.Indptr = make([]int, pn)
+	for i := 0; i < len(c.matrix.Indptr); i++ {
+		c.matrix.Indptr[i] = int(binary.LittleEndian.Uint64(data[p : p+sizeInt64]))
+		p += sizeInt64
+	}
+
+	c.matrix.Ind = make([]int, pi)
+	for i := 0; i < len(c.matrix.Ind); i++ {
+		c.matrix.Ind[i] = int(binary.LittleEndian.Uint64(data[p : p+sizeInt64]))
+		p += sizeInt64
+	}
+
+	c.matrix.Data = make([]float64, pd)
+	for i := 0; i < len(c.matrix.Data); i++ {
+		c.matrix.Data[i] = math.Float64frombits(binary.LittleEndian.Uint64(data[p : p+sizeFloat64]))
+		p += sizeFloat64
+	}
+
+	return nil
+}
+
+// UnmarshalBinaryFrom binary deserialises the []byte into the receiver and returns
+// the number of bytes read and an error if any.
+//
+// See MarshalBinary for the on-disk layout.
+//
+// Limited checks on the validity of the binary input are performed:
+//  - an error is returned if the resulting compressed sparse matrix is too
+//  big for the current architecture (e.g. a 16GB matrix written by a
+//  64b application and read back from a 32b application.)
+// UnmarshalBinary does not limit the size of the unmarshaled matrix, and so
+// it should not be used on untrusted data.
+func (c *CSR) UnmarshalBinaryFrom(r io.Reader) (int, error) {
+	var n int
+	var buf [8]byte
+
+	nn, err := readUntilFull(r, buf[:])
+	n += nn
+	if err != nil {
+		return n, err
+	}
+	i := int64(binary.LittleEndian.Uint64(buf[:]))
+
+	nn, err = readUntilFull(r, buf[:])
+	n += nn
+	if err != nil {
+		return n, err
+	}
+	j := int64(binary.LittleEndian.Uint64(buf[:]))
+
+	nn, err = readUntilFull(r, buf[:])
+	n += nn
+	if err != nil {
+		return n, err
+	}
+	indptrn := int64(binary.LittleEndian.Uint64(buf[:]))
+
+	nn, err = readUntilFull(r, buf[:])
+	n += nn
+	if err != nil {
+		return n, err
+	}
+	indn := int64(binary.LittleEndian.Uint64(buf[:]))
+
+	nn, err = readUntilFull(r, buf[:])
+	n += nn
+	if err != nil {
+		return n, err
+	}
+	datan := int64(binary.LittleEndian.Uint64(buf[:]))
+
+	if int(indptrn) < 0 || indptrn > maxLen {
+		return n, errors.New("sparse: data is too big")
+	}
+	if int(indn) < 0 || indn > maxLen {
+		return n, errors.New("sparse: data is too big")
+	}
+	if int(datan) < 0 || datan > maxLen {
+		return n, errors.New("sparse: data is too big")
+	}
+	if i < 0 || j < 0 {
+		return n, errors.New("sparse: dimensions/data size mismatch")
+	}
+
+	c.matrix.I = int(i)
+	c.matrix.J = int(j)
+	c.matrix.Indptr = make([]int, indptrn)
+	c.matrix.Ind = make([]int, indn)
+	c.matrix.Data = make([]float64, datan)
+
+	for i := range c.matrix.Indptr {
+		nn, err = readUntilFull(r, buf[:])
+		n += nn
+		if err != nil {
+			return n, err
+		}
+		c.matrix.Indptr[i] = int(binary.LittleEndian.Uint64(buf[:]))
+	}
+
+	for i := range c.matrix.Ind {
+		nn, err = readUntilFull(r, buf[:])
+		n += nn
+		if err != nil {
+			return n, err
+		}
+		c.matrix.Ind[i] = int(binary.LittleEndian.Uint64(buf[:]))
+	}
+
+	for i := range c.matrix.Data {
+		nn, err = readUntilFull(r, buf[:])
+		n += nn
+		if err != nil {
+			return n, err
+		}
+		c.matrix.Data[i] = math.Float64frombits(binary.LittleEndian.Uint64(buf[:]))
+	}
+
+	return n, nil
+}
+
+// MarshalBinary binary serialises the receiver into a []byte and returns the result.
+//
+// SparseMatrix is little-endian encoded as follows:
+//   0 -  7  number of rows    (int64)
+//   8 - 15  number of columns (int64)
+//  16 - 23  number of indptr  (int64)
+//  24 - 31  number of ind     (int64)
+//  32 - 39  number of non zero elements (int64)
+//  40 - ..  data elements for indptr, ind, and data (float64)
+func (c *CSC) MarshalBinary() ([]byte, error) {
+	bufLen := 5*int64(sizeInt64) + // row and column count plus lengths of the slices
+		int64(len(c.matrix.Indptr))*int64(sizeInt64) + // indptr slice
+		int64(len(c.matrix.Ind))*int64(sizeInt64) + // ind slice
+		int64(len(c.matrix.Data))*int64(sizeFloat64) // data slice
+	if bufLen <= 0 {
+		// bufLen is too big and has wrapped around.
+		return nil, errors.New("sparse: buffer for data is too big")
+	}
+
+	p := 0
+	buf := make([]byte, bufLen)
+	binary.LittleEndian.PutUint64(buf[p:p+sizeInt64], uint64(c.matrix.I))
+	p += sizeInt64
+	binary.LittleEndian.PutUint64(buf[p:p+sizeInt64], uint64(c.matrix.J))
+	p += sizeInt64
+	binary.LittleEndian.PutUint64(buf[p:p+sizeInt64], uint64(len(c.matrix.Indptr)))
+	p += sizeInt64
+	binary.LittleEndian.PutUint64(buf[p:p+sizeInt64], uint64(len(c.matrix.Ind)))
+	p += sizeInt64
+	binary.LittleEndian.PutUint64(buf[p:p+sizeInt64], uint64(len(c.matrix.Data)))
+	p += sizeInt64
+
+	for _, x := range c.matrix.Indptr {
+		binary.LittleEndian.PutUint64(buf[p:p+sizeInt64], uint64(x))
+		p += sizeInt64
+	}
+
+	for _, x := range c.matrix.Ind {
+		binary.LittleEndian.PutUint64(buf[p:p+sizeInt64], uint64(x))
+		p += sizeInt64
+	}
+
+	for _, x := range c.matrix.Data {
+		binary.LittleEndian.PutUint64(buf[p:p+sizeFloat64], math.Float64bits(x))
+		p += sizeFloat64
+	}
+
+	return buf, nil
+}
+
+// MarshalBinaryTo binary serialises the receiver and writes it into w.
+// MarshalBinaryTo returns the number of bytes written into w and an error, if any.
+//
+// See MarshalBinary for the serialised layout.
+func (c *CSC) MarshalBinaryTo(w io.Writer) (int, error) {
+	var n int
+	var buf [8]byte
+	binary.LittleEndian.PutUint64(buf[:], uint64(c.matrix.I))
+	nn, err := w.Write(buf[:])
+	n += nn
+	if err != nil {
+		return n, err
+	}
+	binary.LittleEndian.PutUint64(buf[:], uint64(c.matrix.J))
+	nn, err = w.Write(buf[:])
+	n += nn
+	if err != nil {
+		return n, err
+	}
+	binary.LittleEndian.PutUint64(buf[:], uint64(len(c.matrix.Indptr)))
+	nn, err = w.Write(buf[:])
+	n += nn
+	if err != nil {
+		return n, err
+	}
+	binary.LittleEndian.PutUint64(buf[:], uint64(len(c.matrix.Ind)))
+	nn, err = w.Write(buf[:])
+	n += nn
+	if err != nil {
+		return n, err
+	}
+	binary.LittleEndian.PutUint64(buf[:], uint64(len(c.matrix.Data)))
+	nn, err = w.Write(buf[:])
+	n += nn
+	if err != nil {
+		return n, err
+	}
+
+	for _, x := range c.matrix.Indptr {
+		binary.LittleEndian.PutUint64(buf[:], uint64(x))
+		nn, err = w.Write(buf[:])
+		n += nn
+		if err != nil {
+			return n, err
+		}
+	}
+
+	for _, x := range c.matrix.Ind {
+		binary.LittleEndian.PutUint64(buf[:], uint64(x))
+		nn, err = w.Write(buf[:])
+		n += nn
+		if err != nil {
+			return n, err
+		}
+	}
+
+	for _, x := range c.matrix.Data {
+		binary.LittleEndian.PutUint64(buf[:], math.Float64bits(x))
+		nn, err = w.Write(buf[:])
+		n += nn
+		if err != nil {
+			return n, err
+		}
+	}
+
+	return n, nil
+}
+
+// UnmarshalBinary binary deserialises the []byte into the receiver.
+// It panics if the receiver is a non-zero DIA matrix.
+//
+// See MarshalBinary for the on-disk layout.
+//
+// Limited checks on the validity of the binary input are performed:
+//  - an error is returned if the resulting compressed sprase matrix is too
+//  big for the current architecture (e.g. a 16GB matrix written by a
+//  64b application and read back from a 32b application.)
+// UnmarshalBinary does not limit the size of the unmarshaled matrix, and so
+// it should not be used on untrusted data.
+func (c *CSC) UnmarshalBinary(data []byte) error {
+	if len(data) < 5*sizeInt64 {
+		return errors.New("sparse: data is missing required attributes")
+	}
+
+	p := 0
+	c.matrix.I = int(binary.LittleEndian.Uint64(data[p : p+sizeInt64]))
+	p += sizeInt64
+	c.matrix.J = int(binary.LittleEndian.Uint64(data[p : p+sizeInt64]))
+	p += sizeInt64
+	pn := int64(binary.LittleEndian.Uint64(data[p : p+sizeInt64]))
+	p += sizeInt64
+	pi := int64(binary.LittleEndian.Uint64(data[p : p+sizeInt64]))
+	p += sizeInt64
+	pd := int64(binary.LittleEndian.Uint64(data[p : p+sizeInt64]))
+	p += sizeInt64
+
+	// if int(nnz) < 0 || nnz > maxLen {
+	// 	return errors.New("sparse: data is too big")
+	// }
+	// if r < 0 || c < 0 || r < nnz || c < nnz {
+	// 	return errors.New("sparse: dimensions/data size mismatch")
+	// }
+	// if len(data) != int(nnz)*sizeFloat64+3*sizeInt64 {
+	// 	return errors.New("sparse: data/buffer size mismatch")
+	// }
+
+	c.matrix.Indptr = make([]int, pn)
+	for i := 0; i < len(c.matrix.Indptr); i++ {
+		c.matrix.Indptr[i] = int(binary.LittleEndian.Uint64(data[p : p+sizeInt64]))
+		p += sizeInt64
+	}
+
+	c.matrix.Ind = make([]int, pi)
+	for i := 0; i < len(c.matrix.Ind); i++ {
+		c.matrix.Ind[i] = int(binary.LittleEndian.Uint64(data[p : p+sizeInt64]))
+		p += sizeInt64
+	}
+
+	c.matrix.Data = make([]float64, pd)
+	for i := 0; i < len(c.matrix.Data); i++ {
+		c.matrix.Data[i] = math.Float64frombits(binary.LittleEndian.Uint64(data[p : p+sizeFloat64]))
+		p += sizeFloat64
+	}
+
+	return nil
+}
+
+// UnmarshalBinaryFrom binary deserialises the []byte into the receiver and returns
+// the number of bytes read and an error if any.
+//
+// See MarshalBinary for the on-disk layout.
+//
+// Limited checks on the validity of the binary input are performed:
+//  - an error is returned if the resulting compressed sparse matrix is too
+//  big for the current architecture (e.g. a 16GB matrix written by a
+//  64b application and read back from a 32b application.)
+// UnmarshalBinary does not limit the size of the unmarshaled matrix, and so
+// it should not be used on untrusted data.
+func (c *CSC) UnmarshalBinaryFrom(r io.Reader) (int, error) {
+	var n int
+	var buf [8]byte
+
+	nn, err := readUntilFull(r, buf[:])
+	n += nn
+	if err != nil {
+		return n, err
+	}
+	i := int64(binary.LittleEndian.Uint64(buf[:]))
+
+	nn, err = readUntilFull(r, buf[:])
+	n += nn
+	if err != nil {
+		return n, err
+	}
+	j := int64(binary.LittleEndian.Uint64(buf[:]))
+
+	nn, err = readUntilFull(r, buf[:])
+	n += nn
+	if err != nil {
+		return n, err
+	}
+	indptrn := int64(binary.LittleEndian.Uint64(buf[:]))
+
+	nn, err = readUntilFull(r, buf[:])
+	n += nn
+	if err != nil {
+		return n, err
+	}
+	indn := int64(binary.LittleEndian.Uint64(buf[:]))
+
+	nn, err = readUntilFull(r, buf[:])
+	n += nn
+	if err != nil {
+		return n, err
+	}
+	datan := int64(binary.LittleEndian.Uint64(buf[:]))
+
+	if int(indptrn) < 0 || indptrn > maxLen {
+		return n, errors.New("sparse: data is too big")
+	}
+	if int(indn) < 0 || indn > maxLen {
+		return n, errors.New("sparse: data is too big")
+	}
+	if int(datan) < 0 || datan > maxLen {
+		return n, errors.New("sparse: data is too big")
+	}
+	if i < 0 || j < 0 {
+		return n, errors.New("sparse: dimensions/data size mismatch")
+	}
+
+	c.matrix.I = int(i)
+	c.matrix.J = int(j)
+	c.matrix.Indptr = make([]int, indptrn)
+	c.matrix.Ind = make([]int, indn)
+	c.matrix.Data = make([]float64, datan)
+
+	for i := range c.matrix.Indptr {
+		nn, err = readUntilFull(r, buf[:])
+		n += nn
+		if err != nil {
+			return n, err
+		}
+		c.matrix.Indptr[i] = int(binary.LittleEndian.Uint64(buf[:]))
+	}
+
+	for i := range c.matrix.Ind {
+		nn, err = readUntilFull(r, buf[:])
+		n += nn
+		if err != nil {
+			return n, err
+		}
+		c.matrix.Ind[i] = int(binary.LittleEndian.Uint64(buf[:]))
+	}
+
+	for i := range c.matrix.Data {
+		nn, err = readUntilFull(r, buf[:])
+		n += nn
+		if err != nil {
+			return n, err
+		}
+		c.matrix.Data[i] = math.Float64frombits(binary.LittleEndian.Uint64(buf[:]))
+	}
+
+	return n, nil
+}
+
+// MarshalBinary binary serialises the receiver into a []byte and returns the result.
+//
+// compressedSparse is little-endian encoded as follows:
+//   0 -  7  number of rows    (int64)
+//   8 - 15  number of columns (int64)
+//  16 - 16  colMajor          (bool)
+//  17 - 17  cononicalised     (bool)
+//  17 - 25  number of indptr  (int64)
+//  26 - 33  number of ind     (int64)
+//  34 - 41  number of non zero elements (int64)
+//  42 - ..  data elements for indptr, ind, and data (float64)
+func (c *COO) MarshalBinary() ([]byte, error) {
+	bufLen := 5*int64(sizeInt64) + // row and column count plus lengths of the slices
+		2 + // colMajor and canonicalised booleans
+		int64(len(c.rows))*int64(sizeInt64) + // rows slice
+		int64(len(c.cols))*int64(sizeInt64) + // cols slice
+		int64(len(c.data))*int64(sizeFloat64) // data slice
+	if bufLen <= 0 {
+		// bufLen is too big and has wrapped around.
+		return nil, errors.New("sparse: buffer for data is too big")
+	}
+	p := 0
+	buf := make([]byte, bufLen)
+	binary.LittleEndian.PutUint64(buf[p:p+sizeInt64], uint64(c.r))
+	p += sizeInt64
+	binary.LittleEndian.PutUint64(buf[p:p+sizeInt64], uint64(c.c))
+	p += sizeInt64
+	if c.colMajor {
+		buf[p] = 1
+	}
+	p++
+	if c.canonicalised {
+		buf[p] = 1
+	}
+	p++
+	binary.LittleEndian.PutUint64(buf[p:p+sizeInt64], uint64(len(c.rows)))
+	p += sizeInt64
+	binary.LittleEndian.PutUint64(buf[p:p+sizeInt64], uint64(len(c.cols)))
+	p += sizeInt64
+	binary.LittleEndian.PutUint64(buf[p:p+sizeInt64], uint64(len(c.data)))
+	p += sizeInt64
+
+	for _, x := range c.rows {
+		binary.LittleEndian.PutUint64(buf[p:p+sizeInt64], uint64(x))
+		p += sizeInt64
+	}
+
+	for _, x := range c.cols {
+		binary.LittleEndian.PutUint64(buf[p:p+sizeInt64], uint64(x))
+		p += sizeInt64
+	}
+
+	for _, x := range c.data {
+		binary.LittleEndian.PutUint64(buf[p:p+sizeFloat64], math.Float64bits(x))
+		p += sizeFloat64
+	}
+
+	return buf, nil
+}
+
+// MarshalBinaryTo binary serialises the receiver and writes it into w.
+// MarshalBinaryTo returns the number of bytes written into w and an error, if any.
+//
+// See MarshalBinary for the serialised layout.
+func (c *COO) MarshalBinaryTo(w io.Writer) (int, error) {
+	var n int
+	var buf [8]byte
+	binary.LittleEndian.PutUint64(buf[:], uint64(c.r))
+	nn, err := w.Write(buf[:])
+	n += nn
+	if err != nil {
+		return n, err
+	}
+	binary.LittleEndian.PutUint64(buf[:], uint64(c.c))
+	nn, err = w.Write(buf[:])
+	n += nn
+	if err != nil {
+		return n, err
+	}
+
+	var buf2 [2]byte
+	if c.colMajor {
+		buf2[0] = 1
+	}
+	if c.canonicalised {
+		buf2[1] = 1
+	}
+	nn, err = w.Write(buf2[:])
+	n += nn
+	if err != nil {
+		return n, err
+	}
+
+	binary.LittleEndian.PutUint64(buf[:], uint64(len(c.rows)))
+	nn, err = w.Write(buf[:])
+	n += nn
+	if err != nil {
+		return n, err
+	}
+	binary.LittleEndian.PutUint64(buf[:], uint64(len(c.cols)))
+	nn, err = w.Write(buf[:])
+	n += nn
+	if err != nil {
+		return n, err
+	}
+	binary.LittleEndian.PutUint64(buf[:], uint64(len(c.data)))
+	nn, err = w.Write(buf[:])
+	n += nn
+	if err != nil {
+		return n, err
+	}
+
+	for _, x := range c.rows {
+		binary.LittleEndian.PutUint64(buf[:], uint64(x))
+		nn, err = w.Write(buf[:])
+		n += nn
+		if err != nil {
+			return n, err
+		}
+	}
+
+	for _, x := range c.cols {
+		binary.LittleEndian.PutUint64(buf[:], uint64(x))
+		nn, err = w.Write(buf[:])
+		n += nn
+		if err != nil {
+			return n, err
+		}
+	}
+
+	for _, x := range c.data {
+		binary.LittleEndian.PutUint64(buf[:], math.Float64bits(x))
+		nn, err = w.Write(buf[:])
+		n += nn
+		if err != nil {
+			return n, err
+		}
+	}
+
+	return n, nil
+}
+
+// UnmarshalBinary binary deserialises the []byte into the receiver.
+// It panics if the receiver is a non-zero DIA matrix.
+//
+// See MarshalBinary for the on-disk layout.
+//
+// Limited checks on the validity of the binary input are performed:
+//  - an error is returned if the resulting compressed sprase matrix is too
+//  big for the current architecture (e.g. a 16GB matrix written by a
+//  64b application and read back from a 32b application.)
+// UnmarshalBinary does not limit the size of the unmarshaled matrix, and so
+// it should not be used on untrusted data.
+func (c *COO) UnmarshalBinary(data []byte) error {
+	if len(data) < 5*sizeInt64+2 {
+		return errors.New("sparse: data is missing required attributes")
+	}
+
+	p := 0
+	c.r = int(binary.LittleEndian.Uint64(data[p : p+sizeInt64]))
+	p += sizeInt64
+	c.c = int(binary.LittleEndian.Uint64(data[p : p+sizeInt64]))
+	p += sizeInt64
+	c.colMajor = data[p] == 1
+	p++
+	c.canonicalised = data[p] == 1
+	p++
+	pr := int64(binary.LittleEndian.Uint64(data[p : p+sizeInt64]))
+	p += sizeInt64
+	pc := int64(binary.LittleEndian.Uint64(data[p : p+sizeInt64]))
+	p += sizeInt64
+	pd := int64(binary.LittleEndian.Uint64(data[p : p+sizeInt64]))
+	p += sizeInt64
+
+	// if int(nnz) < 0 || nnz > maxLen {
+	// 	return errors.New("sparse: data is too big")
+	// }
+	// if r < 0 || c < 0 || r < nnz || c < nnz {
+	// 	return errors.New("sparse: dimensions/data size mismatch")
+	// }
+	// if len(data) != int(nnz)*sizeFloat64+3*sizeInt64 {
+	// 	return errors.New("sparse: data/buffer size mismatch")
+	// }
+
+	c.rows = make([]int, pr)
+	for i := 0; i < len(c.rows); i++ {
+		c.rows[i] = int(binary.LittleEndian.Uint64(data[p : p+sizeInt64]))
+		p += sizeInt64
+	}
+
+	c.cols = make([]int, pc)
+	for i := 0; i < len(c.cols); i++ {
+		c.cols[i] = int(binary.LittleEndian.Uint64(data[p : p+sizeInt64]))
+		p += sizeInt64
+	}
+
+	c.data = make([]float64, pd)
+	for i := 0; i < len(c.data); i++ {
+		c.data[i] = math.Float64frombits(binary.LittleEndian.Uint64(data[p : p+sizeFloat64]))
+		p += sizeFloat64
+	}
+
+	return nil
+}
+
+// UnmarshalBinaryFrom binary deserialises the []byte into the receiver and returns
+// the number of bytes read and an error if any.
+//
+// See MarshalBinary for the on-disk layout.
+//
+// Limited checks on the validity of the binary input are performed:
+//  - an error is returned if the resulting compressed sparse matrix is too
+//  big for the current architecture (e.g. a 16GB matrix written by a
+//  64b application and read back from a 32b application.)
+// UnmarshalBinary does not limit the size of the unmarshaled matrix, and so
+// it should not be used on untrusted data.
+func (c *COO) UnmarshalBinaryFrom(r io.Reader) (int, error) {
+	var n int
+	var buf [8]byte
+	var buf2 [2]byte
+
+	nn, err := readUntilFull(r, buf[:])
+	n += nn
+	if err != nil {
+		return n, err
+	}
+	i := int64(binary.LittleEndian.Uint64(buf[:]))
+
+	nn, err = readUntilFull(r, buf[:])
+	n += nn
+	if err != nil {
+		return n, err
+	}
+	j := int64(binary.LittleEndian.Uint64(buf[:]))
+
+	nn, err = readUntilFull(r, buf2[:])
+	n += nn
+	if err != nil {
+		return n, err
+	}
+	cm := buf2[0] == 1
+	co := buf2[1] == 1
+
+	nn, err = readUntilFull(r, buf[:])
+	n += nn
+	if err != nil {
+		return n, err
+	}
+	rcnt := int64(binary.LittleEndian.Uint64(buf[:]))
+
+	nn, err = readUntilFull(r, buf[:])
+	n += nn
+	if err != nil {
+		return n, err
+	}
+	ccnt := int64(binary.LittleEndian.Uint64(buf[:]))
+
+	nn, err = readUntilFull(r, buf[:])
+	n += nn
+	if err != nil {
+		return n, err
+	}
+	datan := int64(binary.LittleEndian.Uint64(buf[:]))
+
+	if int(rcnt) < 0 || rcnt > maxLen {
+		return n, errors.New("sparse: data is too big")
+	}
+	if int(ccnt) < 0 || ccnt > maxLen {
+		return n, errors.New("sparse: data is too big")
+	}
+	if int(datan) < 0 || datan > maxLen {
+		return n, errors.New("sparse: data is too big")
+	}
+	if i < 0 || j < 0 {
+		return n, errors.New("sparse: dimensions/data size mismatch")
+	}
+
+	c.r = int(i)
+	c.c = int(j)
+	c.colMajor = cm
+	c.canonicalised = co
+	c.rows = make([]int, rcnt)
+	c.cols = make([]int, ccnt)
+	c.data = make([]float64, datan)
+
+	for i := range c.rows {
+		nn, err = readUntilFull(r, buf[:])
+		n += nn
+		if err != nil {
+			return n, err
+		}
+		c.rows[i] = int(binary.LittleEndian.Uint64(buf[:]))
+	}
+
+	for i := range c.cols {
+		nn, err = readUntilFull(r, buf[:])
+		n += nn
+		if err != nil {
+			return n, err
+		}
+		c.cols[i] = int(binary.LittleEndian.Uint64(buf[:]))
+	}
+
+	for i := range c.data {
+		nn, err = readUntilFull(r, buf[:])
+		n += nn
+		if err != nil {
+			return n, err
+		}
+		c.data[i] = math.Float64frombits(binary.LittleEndian.Uint64(buf[:]))
+	}
+
+	return n, nil
+}
+
+/*
+type key struct {
+	i, j int
+}
+type DOK struct {
+	r        int
+	c        int
+	elements map[key]float64
+}
+*/
+
+// MarshalBinary binary serialises the receiver into a []byte and returns the result.
+//
+// DOK is little-endian encoded as follows:
+//   0 -  7  number of rows    (int64)
+//   8 - 15  number of columns (int64)
+//  16 - ..  data elements     (key + float64)
+func (c *DOK) MarshalBinary() ([]byte, error) {
+	bufLen := 3*int64(sizeInt64) + // row and column count plus number of elements
+		int64(len(c.elements))*int64(sizeInt64+sizeInt64+sizeFloat64) // key + value entry in elements
+	if bufLen <= 0 {
+		// bufLen is too big and has wrapped around.
+		return nil, errors.New("sparse: buffer for data is too big")
+	}
+	p := 0
+	buf := make([]byte, bufLen)
+	binary.LittleEndian.PutUint64(buf[p:p+sizeInt64], uint64(c.r))
+	p += sizeInt64
+	binary.LittleEndian.PutUint64(buf[p:p+sizeInt64], uint64(c.c))
+	p += sizeInt64
+	binary.LittleEndian.PutUint64(buf[p:p+sizeInt64], uint64(len(c.elements)))
+	p += sizeInt64
+
+	for k, v := range c.elements {
+		binary.LittleEndian.PutUint64(buf[p:p+sizeInt64], uint64(k.i))
+		p += sizeInt64
+		binary.LittleEndian.PutUint64(buf[p:p+sizeInt64], uint64(k.j))
+		p += sizeInt64
+		binary.LittleEndian.PutUint64(buf[p:p+sizeFloat64], math.Float64bits(v))
+		p += sizeFloat64
+	}
+	return buf, nil
+}
+
+// MarshalBinaryTo binary serialises the receiver and writes it into w.
+// MarshalBinaryTo returns the number of bytes written into w and an error, if any.
+//
+// See MarshalBinary for the serialised layout.
+func (c *DOK) MarshalBinaryTo(w io.Writer) (int, error) {
+	var n int
+	var buf [8]byte
+	binary.LittleEndian.PutUint64(buf[:], uint64(c.r))
+	nn, err := w.Write(buf[:])
+	n += nn
+	if err != nil {
+		return n, err
+	}
+	binary.LittleEndian.PutUint64(buf[:], uint64(c.c))
+	nn, err = w.Write(buf[:])
+	n += nn
+	if err != nil {
+		return n, err
+	}
+
+	binary.LittleEndian.PutUint64(buf[:], uint64(len(c.elements)))
+	nn, err = w.Write(buf[:])
+	n += nn
+	if err != nil {
+		return n, err
+	}
+
+	for k, v := range c.elements {
+		binary.LittleEndian.PutUint64(buf[:], uint64(k.i))
+		nn, err = w.Write(buf[:])
+		n += nn
+		if err != nil {
+			return n, err
+		}
+		binary.LittleEndian.PutUint64(buf[:], uint64(k.j))
+		nn, err = w.Write(buf[:])
+		n += nn
+		if err != nil {
+			return n, err
+		}
+		binary.LittleEndian.PutUint64(buf[:], math.Float64bits(v))
+		nn, err = w.Write(buf[:])
+		n += nn
+		if err != nil {
+			return n, err
+		}
+	}
+	return n, nil
+}
+
+// UnmarshalBinary binary deserialises the []byte into the receiver.
+// It panics if the receiver is a non-zero DIA matrix.
+//
+// See MarshalBinary for the on-disk layout.
+//
+// Limited checks on the validity of the binary input are performed:
+//  - an error is returned if the resulting compressed sprase matrix is too
+//  big for the current architecture (e.g. a 16GB matrix written by a
+//  64b application and read back from a 32b application.)
+// UnmarshalBinary does not limit the size of the unmarshaled matrix, and so
+// it should not be used on untrusted data.
+func (c *DOK) UnmarshalBinary(data []byte) error {
+	if len(data) < 3*sizeInt64 {
+		return errors.New("sparse: data is missing required attributes")
+	}
+
+	p := 0
+	c.r = int(binary.LittleEndian.Uint64(data[p : p+sizeInt64]))
+	p += sizeInt64
+	c.c = int(binary.LittleEndian.Uint64(data[p : p+sizeInt64]))
+	p += sizeInt64
+	cnt := int64(binary.LittleEndian.Uint64(data[p : p+sizeInt64]))
+	p += sizeInt64
+
+	// if int(nnz) < 0 || nnz > maxLen {
+	// 	return errors.New("sparse: data is too big")
+	// }
+	// if r < 0 || c < 0 || r < nnz || c < nnz {
+	// 	return errors.New("sparse: dimensions/data size mismatch")
+	// }
+	// if len(data) != int(nnz)*sizeFloat64+3*sizeInt64 {
+	// 	return errors.New("sparse: data/buffer size mismatch")
+	// }
+
+	var k key
+	var v float64
+	c.elements = make(map[key]float64, cnt)
+	for i := 0; i < int(cnt); i++ {
+		k.i = int(binary.LittleEndian.Uint64(data[p : p+sizeInt64]))
+		p += sizeInt64
+		k.j = int(binary.LittleEndian.Uint64(data[p : p+sizeInt64]))
+		p += sizeInt64
+		v = math.Float64frombits(binary.LittleEndian.Uint64(data[p : p+sizeFloat64]))
+		p += sizeFloat64
+		c.elements[k] = v
+	}
+	return nil
+}
+
+// UnmarshalBinaryFrom binary deserialises the []byte into the receiver and returns
+// the number of bytes read and an error if any.
+//
+// See MarshalBinary for the on-disk layout.
+//
+// Limited checks on the validity of the binary input are performed:
+//  - an error is returned if the resulting compressed sparse matrix is too
+//  big for the current architecture (e.g. a 16GB matrix written by a
+//  64b application and read back from a 32b application.)
+// UnmarshalBinary does not limit the size of the unmarshaled matrix, and so
+// it should not be used on untrusted data.
+func (c *DOK) UnmarshalBinaryFrom(r io.Reader) (int, error) {
+	var n int
+	var buf [8]byte
+
+	nn, err := readUntilFull(r, buf[:])
+	n += nn
+	if err != nil {
+		return n, err
+	}
+	i := int64(binary.LittleEndian.Uint64(buf[:]))
+
+	nn, err = readUntilFull(r, buf[:])
+	n += nn
+	if err != nil {
+		return n, err
+	}
+	j := int64(binary.LittleEndian.Uint64(buf[:]))
+
+	nn, err = readUntilFull(r, buf[:])
+	n += nn
+	if err != nil {
+		return n, err
+	}
+	cnt := int64(binary.LittleEndian.Uint64(buf[:]))
+
+	if int(cnt) < 0 || cnt > maxLen {
+		return n, errors.New("sparse: data is too big")
+	}
+	if i < 0 || j < 0 {
+		return n, errors.New("sparse: dimensions/data size mismatch")
+	}
+
+	c.r = int(i)
+	c.c = int(j)
+	c.elements = make(map[key]float64, cnt)
+
+	var k key
+	var v float64
+	for i := 0; i < int(cnt); i++ {
+		nn, err = readUntilFull(r, buf[:])
+		n += nn
+		if err != nil {
+			return n, err
+		}
+		k.i = int(binary.LittleEndian.Uint64(buf[:]))
+		nn, err = readUntilFull(r, buf[:])
+		n += nn
+		if err != nil {
+			return n, err
+		}
+		k.j = int(binary.LittleEndian.Uint64(buf[:]))
+		nn, err = readUntilFull(r, buf[:])
+		n += nn
+		if err != nil {
+			return n, err
+		}
+		v = math.Float64frombits(binary.LittleEndian.Uint64(buf[:]))
+		c.elements[k] = v
+	}
 	return n, nil
 }
 

--- a/persistence_test.go
+++ b/persistence_test.go
@@ -2,8 +2,9 @@ package sparse
 
 import (
 	"bytes"
-	"gonum.org/v1/gonum/mat"
 	"testing"
+
+	"gonum.org/v1/gonum/mat"
 )
 
 var diagonals = []struct {
@@ -105,6 +106,684 @@ func TestDIAUnmarshalFrom(t *testing.T) {
 			t.Errorf("error decoding: lengths differ.\n got=%d\nwant=%d\n",
 				n, len(test.raw),
 			)
+		}
+		if !mat.Equal(&v, test.want) {
+			t.Errorf("error decoding: values differ.\n got=%v\nwant=%v\n",
+				&v,
+				test.want,
+			)
+		}
+	}
+}
+
+var (
+	compressedCSR = []struct {
+		want *CSR
+		raw  []byte
+	}{
+		{
+			want: NewCSR(2, 2, []int{0, 1, 2}, []int{1, 0}, []float64{0.5, -0.5}),
+			raw: []byte(
+				"\x02\x00\x00\x00\x00\x00\x00\x00" + // 2
+					"\x02\x00\x00\x00\x00\x00\x00\x00" + // 2
+					"\x03\x00\x00\x00\x00\x00\x00\x00" + // 3 = len(indptr)
+					"\x02\x00\x00\x00\x00\x00\x00\x00" + // 3 = len(ind)
+					"\x02\x00\x00\x00\x00\x00\x00\x00" + // 3 = len(data)
+					"\x00\x00\x00\x00\x00\x00\x00\x00" + // 0
+					"\x01\x00\x00\x00\x00\x00\x00\x00" + // 1
+					"\x02\x00\x00\x00\x00\x00\x00\x00" + // 2
+					"\x01\x00\x00\x00\x00\x00\x00\x00" + // 1
+					"\x00\x00\x00\x00\x00\x00\x00\x00" + // 2
+					"\x00\x00\x00\x00\x00\x00\xE0\x3F" + // 0.5
+					"\x00\x00\x00\x00\x00\x00\xE0\xBF", // -0.5
+			),
+		},
+		{
+			want: NewCSR(2, 3, []int{0, 1, 2}, []int{1, 0}, []float64{0.5, -0.5}),
+			raw: []byte(
+				"\x02\x00\x00\x00\x00\x00\x00\x00" + // 2
+					"\x03\x00\x00\x00\x00\x00\x00\x00" + // 3
+					"\x03\x00\x00\x00\x00\x00\x00\x00" + // 3 = len(indptr)
+					"\x02\x00\x00\x00\x00\x00\x00\x00" + // 3 = len(ind)
+					"\x02\x00\x00\x00\x00\x00\x00\x00" + // 3 = len(data)
+					"\x00\x00\x00\x00\x00\x00\x00\x00" + // 0
+					"\x01\x00\x00\x00\x00\x00\x00\x00" + // 1
+					"\x02\x00\x00\x00\x00\x00\x00\x00" + // 2
+					"\x01\x00\x00\x00\x00\x00\x00\x00" + // 1
+					"\x00\x00\x00\x00\x00\x00\x00\x00" + // 2
+					"\x00\x00\x00\x00\x00\x00\xE0\x3F" + // 0.5
+					"\x00\x00\x00\x00\x00\x00\xE0\xBF", // -0.5
+			),
+		},
+		{
+			want: NewCSR(3, 2, []int{0, 1, 2, 2}, []int{1, 0}, []float64{0.5, -0.5}),
+			raw: []byte(
+				"\x03\x00\x00\x00\x00\x00\x00\x00" + // 3
+					"\x02\x00\x00\x00\x00\x00\x00\x00" + // 2
+					"\x04\x00\x00\x00\x00\x00\x00\x00" + // 3 = len(indptr)
+					"\x02\x00\x00\x00\x00\x00\x00\x00" + // 3 = len(ind)
+					"\x02\x00\x00\x00\x00\x00\x00\x00" + // 3 = len(data)
+					"\x00\x00\x00\x00\x00\x00\x00\x00" + // 0
+					"\x01\x00\x00\x00\x00\x00\x00\x00" + // 1
+					"\x02\x00\x00\x00\x00\x00\x00\x00" + // 2
+					"\x02\x00\x00\x00\x00\x00\x00\x00" + // 2
+					"\x01\x00\x00\x00\x00\x00\x00\x00" + // 1
+					"\x00\x00\x00\x00\x00\x00\x00\x00" + // 2
+					"\x00\x00\x00\x00\x00\x00\xE0\x3F" + // 0.5
+					"\x00\x00\x00\x00\x00\x00\xE0\xBF", // -0.5
+			),
+		},
+	}
+	compressedCSC = []struct {
+		want *CSC
+		raw  []byte
+	}{
+		{
+			want: NewCSC(2, 2, []int{0, 1, 2}, []int{1, 0}, []float64{0.5, -0.5}),
+			raw: []byte(
+				"\x02\x00\x00\x00\x00\x00\x00\x00" + // 2
+					"\x02\x00\x00\x00\x00\x00\x00\x00" + // 2
+					"\x03\x00\x00\x00\x00\x00\x00\x00" + // 3 = len(indptr)
+					"\x02\x00\x00\x00\x00\x00\x00\x00" + // 3 = len(ind)
+					"\x02\x00\x00\x00\x00\x00\x00\x00" + // 3 = len(data)
+					"\x00\x00\x00\x00\x00\x00\x00\x00" + // 0
+					"\x01\x00\x00\x00\x00\x00\x00\x00" + // 1
+					"\x02\x00\x00\x00\x00\x00\x00\x00" + // 2
+					"\x01\x00\x00\x00\x00\x00\x00\x00" + // 1
+					"\x00\x00\x00\x00\x00\x00\x00\x00" + // 2
+					"\x00\x00\x00\x00\x00\x00\xE0\x3F" + // 0.5
+					"\x00\x00\x00\x00\x00\x00\xE0\xBF", // -0.5
+			),
+		},
+		{
+			want: NewCSC(2, 3, []int{0, 1, 2, 2}, []int{1, 0}, []float64{0.5, -0.5}),
+			raw: []byte(
+				"\x03\x00\x00\x00\x00\x00\x00\x00" + // 3
+					"\x02\x00\x00\x00\x00\x00\x00\x00" + // 2
+					"\x04\x00\x00\x00\x00\x00\x00\x00" + // 3 = len(indptr)
+					"\x02\x00\x00\x00\x00\x00\x00\x00" + // 3 = len(ind)
+					"\x02\x00\x00\x00\x00\x00\x00\x00" + // 3 = len(data)
+					"\x00\x00\x00\x00\x00\x00\x00\x00" + // 0
+					"\x01\x00\x00\x00\x00\x00\x00\x00" + // 1
+					"\x02\x00\x00\x00\x00\x00\x00\x00" + // 2
+					"\x02\x00\x00\x00\x00\x00\x00\x00" + // 2
+					"\x01\x00\x00\x00\x00\x00\x00\x00" + // 1
+					"\x00\x00\x00\x00\x00\x00\x00\x00" + // 2
+					"\x00\x00\x00\x00\x00\x00\xE0\x3F" + // 0.5
+					"\x00\x00\x00\x00\x00\x00\xE0\xBF", // -0.5
+			),
+		},
+		{
+			want: NewCSC(3, 2, []int{0, 1, 2}, []int{1, 0}, []float64{0.5, -0.5}),
+			raw: []byte(
+				"\x02\x00\x00\x00\x00\x00\x00\x00" + // 2
+					"\x03\x00\x00\x00\x00\x00\x00\x00" + // 3
+					"\x03\x00\x00\x00\x00\x00\x00\x00" + // 3 = len(indptr)
+					"\x02\x00\x00\x00\x00\x00\x00\x00" + // 3 = len(ind)
+					"\x02\x00\x00\x00\x00\x00\x00\x00" + // 3 = len(data)
+					"\x00\x00\x00\x00\x00\x00\x00\x00" + // 0
+					"\x01\x00\x00\x00\x00\x00\x00\x00" + // 1
+					"\x02\x00\x00\x00\x00\x00\x00\x00" + // 2
+					"\x01\x00\x00\x00\x00\x00\x00\x00" + // 1
+					"\x00\x00\x00\x00\x00\x00\x00\x00" + // 2
+					"\x00\x00\x00\x00\x00\x00\xE0\x3F" + // 0.5
+					"\x00\x00\x00\x00\x00\x00\xE0\xBF", // -0.5
+			),
+		},
+	}
+)
+
+func TestCSRMarshalBinary(t *testing.T) {
+	for ti, test := range compressedCSR {
+		t.Logf("**** TestCSRMarshallBinary - Test Run %d.\n", ti+1)
+
+		buf, err := test.want.MarshalBinary()
+		if err != nil {
+			t.Errorf("error encoding: %v\n", err)
+			continue
+		}
+
+		size := 5*int64(sizeInt64) + // row and column count plus lengths of the slices
+			int64(len(test.want.matrix.Indptr))*int64(sizeInt64) + // indptr slice
+			int64(len(test.want.matrix.Ind))*int64(sizeInt64) + // ind slice
+			int64(len(test.want.matrix.Data))*int64(sizeFloat64) // data slice
+		if len(buf) != int(size) {
+			t.Errorf("encoded size test: want=%d got=%d\n", size, len(buf))
+		}
+
+		if !bytes.Equal(buf, test.raw) {
+			t.Errorf("error encoding test: bytes mismatch.\n got=%q\nwant=%q\n",
+				string(buf),
+				string(test.raw),
+			)
+		}
+	}
+}
+
+func TestCSRMarshallTo(t *testing.T) {
+	for ti, test := range compressedCSR {
+		t.Logf("**** TestCSRMarshallTo - Test Run %d.\n", ti+1)
+		buf := new(bytes.Buffer)
+		n, err := test.want.MarshalBinaryTo(buf)
+		if err != nil {
+			t.Errorf("error encoding: %v\n", err)
+			continue
+		}
+
+		size := len(test.want.matrix.Data)*sizeFloat64 + len(test.want.matrix.Indptr)*sizeInt64 +
+			len(test.want.matrix.Ind)*sizeInt64 + 5*sizeInt64
+		if n != size {
+			t.Errorf("encoded size: want=%d got=%d\n", size, n)
+		}
+
+		if !bytes.Equal(buf.Bytes(), test.raw) {
+			t.Errorf("error encoding: bytes mismatch.\n got=%q\nwant=%q\n",
+				string(buf.Bytes()),
+				string(test.raw),
+			)
+		}
+	}
+}
+
+func TestCSRUnmarshalBinary(t *testing.T) {
+	for ti, test := range compressedCSR {
+		t.Logf("**** TestCSRUnmarshal - Test Run %d.\n", ti+1)
+		var v CSR
+		err := v.UnmarshalBinary(test.raw)
+		if err != nil {
+			t.Errorf("error decoding: %v\n", err)
+			continue
+		}
+		if !mat.Equal(&v, test.want) {
+			t.Errorf("error decoding: values differ.\n got=%v\nwant=%v\n",
+				&v,
+				test.want,
+			)
+		}
+	}
+}
+
+func TestCSRUnmarshalFrom(t *testing.T) {
+	for ti, test := range compressedCSR {
+		t.Logf("**** TestCSRUnmarshalFrom - Test Run %d.\n", ti+1)
+		var v CSR
+		buf := bytes.NewReader(test.raw)
+		n, err := v.UnmarshalBinaryFrom(buf)
+		if err != nil {
+			t.Errorf("error decoding: %v\n", err)
+			continue
+		}
+		if n != len(test.raw) {
+			t.Errorf("error decoding: lengths differ.\n got=%d\nwant=%d\n",
+				n, len(test.raw),
+			)
+		}
+		if !mat.Equal(&v, test.want) {
+			t.Errorf("error decoding: values differ.\n got=%v\nwant=%v\n",
+				&v,
+				test.want,
+			)
+		}
+	}
+}
+
+func TestCSCMarshalBinary(t *testing.T) {
+	for ti, test := range compressedCSC {
+		t.Logf("**** TestCSCMarshallBinary - Test Run %d.\n", ti+1)
+
+		buf, err := test.want.MarshalBinary()
+		if err != nil {
+			t.Errorf("error encoding: %v\n", err)
+			continue
+		}
+
+		size := 5*int64(sizeInt64) + // row and column count plus lengths of the slices
+			int64(len(test.want.matrix.Indptr))*int64(sizeInt64) + // indptr slice
+			int64(len(test.want.matrix.Ind))*int64(sizeInt64) + // ind slice
+			int64(len(test.want.matrix.Data))*int64(sizeFloat64) // data slice
+		if len(buf) != int(size) {
+			t.Errorf("encoded size test: want=%d got=%d\n", size, len(buf))
+		}
+
+		if !bytes.Equal(buf, test.raw) {
+			t.Errorf("error encoding test: bytes mismatch.\n got=%q\nwant=%q\n",
+				string(buf),
+				string(test.raw),
+			)
+		}
+	}
+}
+
+func TestCSCMarshallTo(t *testing.T) {
+	for ti, test := range compressedCSC {
+		t.Logf("**** TestCSCMarshallTo - Test Run %d.\n", ti+1)
+		buf := new(bytes.Buffer)
+		n, err := test.want.MarshalBinaryTo(buf)
+		if err != nil {
+			t.Errorf("error encoding: %v\n", err)
+			continue
+		}
+
+		size := len(test.want.matrix.Data)*sizeFloat64 + len(test.want.matrix.Indptr)*sizeInt64 +
+			len(test.want.matrix.Ind)*sizeInt64 + 5*sizeInt64
+		if n != size {
+			t.Errorf("encoded size: want=%d got=%d\n", size, n)
+		}
+
+		if !bytes.Equal(buf.Bytes(), test.raw) {
+			t.Errorf("error encoding: bytes mismatch.\n got=%q\nwant=%q\n",
+				string(buf.Bytes()),
+				string(test.raw),
+			)
+		}
+	}
+}
+
+func TestCSCUnmarshalBinary(t *testing.T) {
+	for ti, test := range compressedCSC {
+		t.Logf("**** TestCSCUnmarshal - Test Run %d.\n", ti+1)
+		var v CSC
+		err := v.UnmarshalBinary(test.raw)
+		if err != nil {
+			t.Errorf("error decoding: %v\n", err)
+			continue
+		}
+		if !mat.Equal(&v, test.want) {
+			t.Errorf("error decoding: values differ.\n got=%v\nwant=%v\n",
+				&v,
+				test.want,
+			)
+		}
+	}
+}
+
+func TestCSCUnmarshalFrom(t *testing.T) {
+	for ti, test := range compressedCSC {
+		t.Logf("**** TestCSCUnmarshalFrom - Test Run %d.\n", ti+1)
+		var v CSC
+		buf := bytes.NewReader(test.raw)
+		n, err := v.UnmarshalBinaryFrom(buf)
+		if err != nil {
+			t.Errorf("error decoding: %v\n", err)
+			continue
+		}
+		if n != len(test.raw) {
+			t.Errorf("error decoding: lengths differ.\n got=%d\nwant=%d\n",
+				n, len(test.raw),
+			)
+		}
+		if !mat.Equal(&v, test.want) {
+			t.Errorf("error decoding: values differ.\n got=%v\nwant=%v\n",
+				&v,
+				test.want,
+			)
+		}
+	}
+}
+
+var (
+	coordinates = []struct {
+		want *COO
+		raw  []byte
+	}{
+		{
+			want: NewCOO(2, 2, []int{0, 1}, []int{1, 0}, []float64{0.5, -0.5}),
+			raw: []byte(
+				"\x02\x00\x00\x00\x00\x00\x00\x00" + // 2
+					"\x02\x00\x00\x00\x00\x00\x00\x00" + // 2
+					"\x00" + // false
+					"\x01" + // true
+					"\x02\x00\x00\x00\x00\x00\x00\x00" + // 2 = len(rows)
+					"\x02\x00\x00\x00\x00\x00\x00\x00" + // 2 = len(cols)
+					"\x02\x00\x00\x00\x00\x00\x00\x00" + // 2 = len(data)
+					"\x00\x00\x00\x00\x00\x00\x00\x00" + // 0
+					"\x01\x00\x00\x00\x00\x00\x00\x00" + // 1
+					"\x01\x00\x00\x00\x00\x00\x00\x00" + // 1
+					"\x00\x00\x00\x00\x00\x00\x00\x00" + // 0
+					"\x00\x00\x00\x00\x00\x00\xE0\x3F" + // 0.5
+					"\x00\x00\x00\x00\x00\x00\xE0\xBF", // -0.5
+			),
+		},
+		{
+			want: NewCOO(2, 3, []int{0, 1}, []int{1, 0}, []float64{0.5, -0.5}),
+			raw: []byte(
+				"\x02\x00\x00\x00\x00\x00\x00\x00" + // 2
+					"\x03\x00\x00\x00\x00\x00\x00\x00" + // 3
+					"\x00" + // false
+					"\x01" + // true
+					"\x02\x00\x00\x00\x00\x00\x00\x00" + // 2 = len(rows)
+					"\x02\x00\x00\x00\x00\x00\x00\x00" + // 2 = len(cols)
+					"\x02\x00\x00\x00\x00\x00\x00\x00" + // 2 = len(data)
+					"\x00\x00\x00\x00\x00\x00\x00\x00" + // 0
+					"\x01\x00\x00\x00\x00\x00\x00\x00" + // 1
+					"\x01\x00\x00\x00\x00\x00\x00\x00" + // 1
+					"\x00\x00\x00\x00\x00\x00\x00\x00" + // 0
+					"\x00\x00\x00\x00\x00\x00\xE0\x3F" + // 0.5
+					"\x00\x00\x00\x00\x00\x00\xE0\xBF", // -0.5
+			),
+		},
+		{
+			want: NewCOO(3, 2, []int{0, 1}, []int{1, 0}, []float64{0.5, -0.5}),
+			raw: []byte(
+				"\x03\x00\x00\x00\x00\x00\x00\x00" + // 3
+					"\x02\x00\x00\x00\x00\x00\x00\x00" + // 2
+					"\x00" + // false
+					"\x01" + // true
+					"\x02\x00\x00\x00\x00\x00\x00\x00" + // 2 = len(rows)
+					"\x02\x00\x00\x00\x00\x00\x00\x00" + // 2 = len(cols)
+					"\x02\x00\x00\x00\x00\x00\x00\x00" + // 2 = len(data)
+					"\x00\x00\x00\x00\x00\x00\x00\x00" + // 0
+					"\x01\x00\x00\x00\x00\x00\x00\x00" + // 1
+					"\x01\x00\x00\x00\x00\x00\x00\x00" + // 1
+					"\x00\x00\x00\x00\x00\x00\x00\x00" + // 0
+					"\x00\x00\x00\x00\x00\x00\xE0\x3F" + // 0.5
+					"\x00\x00\x00\x00\x00\x00\xE0\xBF", // -0.5
+			),
+		},
+	}
+)
+
+func TestCOOMarshalBinary(t *testing.T) {
+	for ti, test := range coordinates {
+		t.Logf("**** TestCOOMarshallBinary - Test Run %d.\n", ti+1)
+
+		buf, err := test.want.MarshalBinary()
+		if err != nil {
+			t.Errorf("error encoding: %v\n", err)
+			continue
+		}
+
+		size := 5*int64(sizeInt64) + // row and column count plus lengths of the slices
+			2 + // colMajor and canonicalised booleans
+			int64(len(test.want.rows))*int64(sizeInt64) + // indptr slice
+			int64(len(test.want.cols))*int64(sizeInt64) + // ind slice
+			int64(len(test.want.data))*int64(sizeFloat64) // data slice
+		if len(buf) != int(size) {
+			t.Errorf("encoded size test: want=%d got=%d\n", size, len(buf))
+		}
+
+		if !bytes.Equal(buf, test.raw) {
+			t.Errorf("error encoding test: bytes mismatch.\n got=%q\nwant=%q\n",
+				string(buf),
+				string(test.raw),
+			)
+		}
+	}
+}
+
+func TestCOOMarshallTo(t *testing.T) {
+	for ti, test := range coordinates {
+		t.Logf("**** TestCOOMarshallTo - Test Run %d.\n", ti+1)
+		buf := new(bytes.Buffer)
+		n, err := test.want.MarshalBinaryTo(buf)
+		if err != nil {
+			t.Errorf("error encoding: %v\n", err)
+			continue
+		}
+
+		size := len(test.want.data)*sizeFloat64 + len(test.want.rows)*sizeInt64 +
+			len(test.want.cols)*sizeInt64 + 5*sizeInt64 + 2
+		if n != size {
+			t.Errorf("encoded size: want=%d got=%d\n", size, n)
+		}
+
+		if !bytes.Equal(buf.Bytes(), test.raw) {
+			t.Errorf("error encoding: bytes mismatch.\n got=%q\nwant=%q\n",
+				string(buf.Bytes()),
+				string(test.raw),
+			)
+		}
+	}
+}
+
+func TestCOOUnmarshalBinary(t *testing.T) {
+	for ti, test := range coordinates {
+		t.Logf("**** TestCOOUnmarshal - Test Run %d.\n", ti+1)
+		var v COO
+		err := v.UnmarshalBinary(test.raw)
+		if err != nil {
+			t.Errorf("error decoding: %v\n", err)
+			continue
+		}
+		if !mat.Equal(&v, test.want) {
+			t.Errorf("error decoding: values differ.\n got=%v\nwant=%v\n",
+				&v,
+				test.want,
+			)
+		}
+	}
+}
+
+func TestCOOUnmarshalFrom(t *testing.T) {
+	for ti, test := range coordinates {
+		t.Logf("**** TestCOOUnmarshalFrom - Test Run %d.\n", ti+1)
+		var v COO
+		buf := bytes.NewReader(test.raw)
+		n, err := v.UnmarshalBinaryFrom(buf)
+		if err != nil {
+			t.Errorf("error decoding: %v\n", err)
+			continue
+		}
+		if n != len(test.raw) {
+			t.Errorf("error decoding: lengths differ.\n got=%d\nwant=%d\n",
+				n, len(test.raw),
+			)
+		}
+		if !mat.Equal(&v, test.want) {
+			t.Errorf("error decoding: values differ.\n got=%v\nwant=%v\n",
+				&v,
+				test.want,
+			)
+		}
+	}
+}
+
+var (
+	elements = []struct {
+		want  *DOK
+		items map[key]float64
+		raw   []byte
+		raw0  []byte
+		raw1  []byte
+	}{
+		{
+			want: NewDOK(2, 2),
+			items: map[key]float64{
+				key{i: 0, j: 1}: 0.5,
+				key{i: 1, j: 0}: -0.5,
+			},
+			raw: []byte(
+				"\x02\x00\x00\x00\x00\x00\x00\x00" + // 2
+					"\x02\x00\x00\x00\x00\x00\x00\x00" + // 2
+					"\x02\x00\x00\x00\x00\x00\x00\x00", // 2 = len(elements)
+			),
+			raw0: []byte(
+				"\x00\x00\x00\x00\x00\x00\x00\x00" + // 0
+					"\x01\x00\x00\x00\x00\x00\x00\x00" + // 1
+					"\x00\x00\x00\x00\x00\x00\xE0\x3F", // 0.5
+			),
+			raw1: []byte(
+				"\x01\x00\x00\x00\x00\x00\x00\x00" + // 1
+					"\x00\x00\x00\x00\x00\x00\x00\x00" + // 0
+					"\x00\x00\x00\x00\x00\x00\xE0\xBF", // -0.5
+			),
+		},
+		{
+			want: NewDOK(2, 3),
+			items: map[key]float64{
+				key{i: 0, j: 1}: 0.5,
+				key{i: 1, j: 0}: -0.5,
+			},
+			raw: []byte(
+				"\x02\x00\x00\x00\x00\x00\x00\x00" + // 2
+					"\x03\x00\x00\x00\x00\x00\x00\x00" + // 2
+					"\x02\x00\x00\x00\x00\x00\x00\x00", // 2 = len(elements)
+			),
+			raw0: []byte(
+				"\x00\x00\x00\x00\x00\x00\x00\x00" + // 0
+					"\x01\x00\x00\x00\x00\x00\x00\x00" + // 1
+					"\x00\x00\x00\x00\x00\x00\xE0\x3F", // 0.5
+			),
+			raw1: []byte(
+				"\x01\x00\x00\x00\x00\x00\x00\x00" + // 1
+					"\x00\x00\x00\x00\x00\x00\x00\x00" + // 0
+					"\x00\x00\x00\x00\x00\x00\xE0\xBF", // -0.5
+			),
+		},
+		{
+			want: NewDOK(3, 2),
+			items: map[key]float64{
+				key{i: 0, j: 1}: 0.5,
+				key{i: 1, j: 0}: -0.5,
+			},
+			raw: []byte(
+				"\x03\x00\x00\x00\x00\x00\x00\x00" + // 2
+					"\x02\x00\x00\x00\x00\x00\x00\x00" + // 2
+					"\x02\x00\x00\x00\x00\x00\x00\x00", // 2 = len(elements)
+			),
+			raw0: []byte(
+				"\x00\x00\x00\x00\x00\x00\x00\x00" + // 0
+					"\x01\x00\x00\x00\x00\x00\x00\x00" + // 1
+					"\x00\x00\x00\x00\x00\x00\xE0\x3F", // 0.5
+			),
+			raw1: []byte(
+				"\x01\x00\x00\x00\x00\x00\x00\x00" + // 1
+					"\x00\x00\x00\x00\x00\x00\x00\x00" + // 0
+					"\x00\x00\x00\x00\x00\x00\xE0\xBF", // -0.5
+			),
+		},
+	}
+)
+
+func TestDOKMarshalBinary(t *testing.T) {
+	for ti, test := range elements {
+		t.Logf("**** TestDOKMarshallBinary - Test Run %d.\n", ti+1)
+
+		for k, v := range test.items {
+			test.want.Set(k.i, k.j, v)
+		}
+		buf, err := test.want.MarshalBinary()
+		if err != nil {
+			t.Errorf("error encoding: %v\n", err)
+			continue
+		}
+
+		// Because iterating over Go maps does not have a predictable order we cannot compare the whole byte slice at once
+		size := 3 * (sizeInt64) // row and column count plus lengths of the slices
+		if !bytes.Equal(buf[:size], test.raw) {
+			t.Errorf("error encoding test: bytes mismatch in header.\n got=%q\nwant=%q\n",
+				string(buf[:size]),
+				string(test.raw),
+			)
+		}
+
+		// There are only 2 elements in the test case so it's one ordering or the the other
+		var a, b []byte
+		offset := size
+		size = len(test.want.elements) * (sizeInt64 + sizeInt64 + sizeFloat64)
+		a = append(test.raw0, test.raw1...)
+		b = append(test.raw1, test.raw0...)
+		if !(bytes.Equal(a, buf[offset:]) || bytes.Equal(b, buf[offset:])) {
+			t.Errorf("error encoding test: bytes mismatch in elements.\n got=%q\nwant(a)=%q\nwant(b)=%q\n",
+				string(buf[offset:]),
+				string(a),
+				string(b),
+			)
+		}
+	}
+}
+
+func TestDOKMarshallTo(t *testing.T) {
+	for ti, test := range elements {
+		t.Logf("**** TestDOKMarshallTo - Test Run %d.\n", ti+1)
+
+		for k, v := range test.items {
+			test.want.Set(k.i, k.j, v)
+		}
+		bb := new(bytes.Buffer)
+		n, err := test.want.MarshalBinaryTo(bb)
+		if err != nil {
+			t.Errorf("error encoding: %v\n", err)
+			continue
+		}
+		buf := bb.Bytes()
+
+		size := 3*(sizeInt64) + len(test.want.elements)*(sizeInt64+sizeInt64+sizeFloat64)
+		if n != size {
+			t.Errorf("encoded size: want=%d got=%d\n", size, n)
+		}
+
+		// Because iterating over Go maps does not have a predictable order we cannot compare the whole byte slice at once
+		size = 3 * (sizeInt64) // row and column count plus lengths of the slices
+		if !bytes.Equal(buf[:size], test.raw) {
+			t.Errorf("error encoding test: bytes mismatch in header.\n got=%q\nwant=%q\n",
+				string(buf[:size]),
+				string(test.raw),
+			)
+		}
+
+		// There are only 2 elements in the test case so it's one ordering or the the other
+		var a, b []byte
+		offset := size
+		size = len(test.want.elements) * (sizeInt64 + sizeInt64 + sizeFloat64)
+		a = append(test.raw0, test.raw1...)
+		b = append(test.raw1, test.raw0...)
+		if !(bytes.Equal(a, buf[offset:]) || bytes.Equal(b, buf[offset:])) {
+			t.Errorf("error encoding test: bytes mismatch in elements.\n got=%q\nwant(a)=%q\nwant(b)=%q\n",
+				string(buf[offset:]),
+				string(a),
+				string(b),
+			)
+		}
+	}
+}
+
+func TestDOKUnmarshalBinary(t *testing.T) {
+	for ti, test := range elements {
+		t.Logf("**** TestDOKUnmarshal - Test Run %d.\n", ti+1)
+		var v DOK
+		raw := test.raw
+		raw = append(raw, test.raw0...)
+		raw = append(raw, test.raw1...)
+		err := v.UnmarshalBinary(raw)
+		if err != nil {
+			t.Errorf("error decoding: %v\n", err)
+			continue
+		}
+
+		for k, v := range test.items {
+			test.want.Set(k.i, k.j, v)
+		}
+		if !mat.Equal(&v, test.want) {
+			t.Errorf("error decoding: values differ.\n got=%v\nwant=%v\n",
+				&v,
+				test.want,
+			)
+		}
+	}
+}
+
+func TestDOKUnmarshalFrom(t *testing.T) {
+	for ti, test := range elements {
+		t.Logf("**** TestDOKUnmarshalFrom - Test Run %d.\n", ti+1)
+		var v DOK
+		raw := test.raw
+		raw = append(raw, test.raw0...)
+		raw = append(raw, test.raw1...)
+		buf := bytes.NewReader(raw)
+		n, err := v.UnmarshalBinaryFrom(buf)
+		if err != nil {
+			t.Errorf("error decoding: %v\n", err)
+			continue
+		}
+		if n != len(raw) {
+			t.Errorf("error decoding: lengths differ.\n got=%d\nwant=%d\n",
+				n, len(raw),
+			)
+		}
+
+		for k, v := range test.items {
+			test.want.Set(k.i, k.j, v)
 		}
 		if !mat.Equal(&v, test.want) {
 			t.Errorf("error decoding: values differ.\n got=%v\nwant=%v\n",


### PR DESCRIPTION
add MashalBinary, MarshalBinaryTo, UnmarshalBinary, UnmarshalBinaryFrom methods for the COO, DOK, CSC, and CSR sparse matrices, tests included.