### PR TITLE
add TODO view in test log

### DIFF
--- a/sparse_test.go
+++ b/sparse_test.go
@@ -1,0 +1,54 @@
+package sparse
+
+import (
+	"bufio"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestTodo(t *testing.T) {
+	// Show all to do`s in comment code
+	source, err := filepath.Glob(fmt.Sprintf("./%s", "*.go"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var amount int
+
+	for i := range source {
+		t.Run(source[i], func(t *testing.T) {
+			file, err := os.Open(source[i])
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer file.Close()
+
+			pos := 0
+			scanner := bufio.NewScanner(file)
+			for scanner.Scan() {
+				line := scanner.Text()
+				pos++
+				index := strings.Index(line, "//")
+				if index < 0 {
+					continue
+				}
+				if !strings.Contains(line, "TODO") {
+					continue
+				}
+				t.Logf("%13s:%-4d %s", source[i], pos, line[index:])
+				amount++
+			}
+
+			if err := scanner.Err(); err != nil {
+				log.Fatal(err)
+			}
+		})
+	}
+	if amount > 0 {
+		t.Logf("Amount TODO: %d", amount)
+	}
+}


### PR DESCRIPTION
Now, result:
```
--- PASS: TestTodo (0.03s)
    --- PASS: TestTodo/benchmarks_test.go (0.01s)
    --- PASS: TestTodo/binary.go (0.00s)
    --- PASS: TestTodo/binary_test.go (0.00s)
    --- PASS: TestTodo/compressed.go (0.00s)
    --- PASS: TestTodo/compressed_arith.go (0.00s)
    	sparse_test.go:42: compressed_arith.go:113  // TODO: handle cases where both matrices are DIA
    	sparse_test.go:42: compressed_arith.go:189  // TODO Consider converting all Sparser args to CSR
    	sparse_test.go:42: compressed_arith.go:300  // TODO optimisation for DIA matrices
    --- PASS: TestTodo/compressed_arith_test.go (0.00s)
    --- PASS: TestTodo/compressed_test.go (0.00s)
    --- PASS: TestTodo/coordinate.go (0.00s)
    --- PASS: TestTodo/coordinate_test.go (0.00s)
    --- PASS: TestTodo/diagonal.go (0.00s)
    --- PASS: TestTodo/diagonal_test.go (0.00s)
    --- PASS: TestTodo/dictionaryofkeys.go (0.00s)
    --- PASS: TestTodo/dictionaryofkeys_test.go (0.00s)
    --- PASS: TestTodo/doc.go (0.00s)
    --- PASS: TestTodo/example_test.go (0.00s)
    --- PASS: TestTodo/matrix.go (0.00s)
    --- PASS: TestTodo/matrix_test.go (0.00s)
    --- PASS: TestTodo/persistence.go (0.00s)
    --- PASS: TestTodo/persistence_test.go (0.00s)
    --- PASS: TestTodo/pool.go (0.00s)
    --- PASS: TestTodo/sparse_test.go (0.00s)
    --- PASS: TestTodo/vector.go (0.00s)
    --- PASS: TestTodo/vector_test.go (0.00s)
```