### PR TITLE
implement mat.tracer for dia, csc and csr types

### DIFF
--- a/benchmarks_test.go
+++ b/benchmarks_test.go
@@ -446,3 +446,32 @@ func BenchmarkNorm(b *testing.B) {
 	}
 	_ = v
 }
+
+var traceResult float64
+
+func BenchmarkTraceCS(b *testing.B) {
+	formats := []MatrixType{CSRFormat, CSCFormat}
+	for s := 100; s <= 1600; s *= 2 {
+		for _, density := range densities {
+			for _, format := range formats {
+				a := Random(format, s, s, density)
+				b.Run(fmt.Sprintf("BenchTraceCS%d/%f-%d", format, density, s), func(b *testing.B) {
+					for n := 0; n < b.N; n++ {
+						traceResult = mat.Trace(a)
+					}
+				})
+			}
+		}
+	}
+}
+
+func BenchmarkTraceDIA(b *testing.B) {
+	for s := 100; s <= 1600; s *= 2 {
+		a := RandomDIA(s, s)
+		b.Run(fmt.Sprintf("BenchTraceDIA-%d", s), func(b *testing.B) {
+			for n := 0; n < b.N; n++ {
+				traceResult = mat.Trace(a)
+			}
+		})
+	}
+}

--- a/compressed.go
+++ b/compressed.go
@@ -96,6 +96,21 @@ func (c *CSR) NNZ() int {
 	return len(c.matrix.Data)
 }
 
+// Trace returns the trace.
+func (c *CSR) Trace() float64 {
+	var trace float64
+	nrows := len(c.matrix.Indptr) - 1
+	for i := 0; i < nrows; i++ {
+		for j := c.matrix.Indptr[i]; j < c.matrix.Indptr[i+1]; j++ {
+			if c.matrix.Ind[j] == i {
+				trace += c.matrix.Data[j]
+				break
+			}
+		}
+	}
+	return trace
+}
+
 // RawMatrix returns a pointer to the underlying blas sparse matrix.
 func (c *CSR) RawMatrix() *blas.SparseMatrix {
 	return &c.matrix
@@ -423,6 +438,21 @@ func (c *CSC) NNZ() int {
 	return len(c.matrix.Data)
 }
 
+// Trace returns the trace.
+func (c *CSC) Trace() float64 {
+	var trace float64
+	ncols := len(c.matrix.Indptr) - 1
+	for i := 0; i < ncols; i++ {
+		for j := c.matrix.Indptr[i]; j < c.matrix.Indptr[i+1]; j++ {
+			if c.matrix.Ind[j] == i {
+				trace += c.matrix.Data[j]
+				break
+			}
+		}
+	}
+	return trace
+}
+
 // RawMatrix returns a pointer to the underlying blas sparse matrix.
 func (c *CSC) RawMatrix() *blas.SparseMatrix {
 	return &c.matrix
@@ -487,6 +517,14 @@ func (c *CSC) ToCSC() *CSC {
 // ToType returns an alternative format version fo the matrix in the format specified.
 func (c *CSC) ToType(matType MatrixType) mat.Matrix {
 	return matType.Convert(c)
+}
+
+// ColNNZ returns the Number of Non Zero values in the specified col i.  ColNNZ will panic if i is out of range.
+func (c *CSC) ColNNZ(i int) int {
+	if uint(i) < 0 || uint(i) >= uint(c.matrix.I) {
+		panic(mat.ErrColAccess)
+	}
+	return c.matrix.Indptr[i+1] - c.matrix.Indptr[i]
 }
 
 // ColView slices the Compressed Sparse Column matrix along its primary axis.

--- a/compressed_test.go
+++ b/compressed_test.go
@@ -3,6 +3,7 @@ package sparse
 import (
 	"testing"
 
+	"gonum.org/v1/gonum/floats"
 	"gonum.org/v1/gonum/mat"
 )
 
@@ -419,5 +420,47 @@ func TestCSRCSCDoNonZero(t *testing.T) {
 				t.Fail()
 			}
 		}
+	}
+}
+
+func TestCSTrace(t *testing.T) {
+	var tests = []struct {
+		s       int
+		theType MatrixType
+		density float32
+	}{
+		{
+			s:       8,
+			theType: CSRFormat,
+			density: 0.1,
+		},
+		{
+			s:       8,
+			theType: CSCFormat,
+			density: 0.1,
+		},
+		{
+			s:       80,
+			theType: CSRFormat,
+			density: 0.75,
+		},
+		{
+			s:       80,
+			theType: CSCFormat,
+			density: 0.75,
+		},
+	}
+	for _, test := range tests {
+		m := Random(test.theType, test.s, test.s, test.density)
+		tr := mat.Trace(m)
+		var checkTr float64
+		for i := 0; i < test.s; i++ {
+			checkTr += m.At(i, i)
+		}
+		if !floats.EqualWithinAbs(tr, checkTr, 1e-13) {
+			t.Logf("trace mismatch: %f vs %f", tr, checkTr)
+			t.Fail()
+		}
+
 	}
 }

--- a/diagonal.go
+++ b/diagonal.go
@@ -1,6 +1,7 @@
 package sparse
 
 import (
+	"gonum.org/v1/gonum/floats"
 	"gonum.org/v1/gonum/mat"
 )
 
@@ -153,4 +154,9 @@ func (d *DIA) MulVecTo(dst []float64, trans bool, x []float64) {
 	for i, v := range d.data {
 		dst[i] += v * x[i]
 	}
+}
+
+// Trace returns the trace.
+func (d *DIA) Trace() float64 {
+	return floats.Sum(d.data)
 }

--- a/diagonal_test.go
+++ b/diagonal_test.go
@@ -3,6 +3,7 @@ package sparse
 import (
 	"testing"
 
+	"gonum.org/v1/gonum/floats"
 	"gonum.org/v1/gonum/mat"
 )
 
@@ -128,5 +129,29 @@ func TestDIADoNonZero(t *testing.T) {
 			t.Logf("Expected %d Non Zero elements but found %d", nnz, matrix.NNZ())
 			t.Fail()
 		}
+	}
+}
+
+func TestDIATrace(t *testing.T) {
+	var tests = []struct {
+		s int
+	}{
+		{s: 8},
+		{s: 32},
+		{s: 100},
+		{s: 123},
+	}
+	for _, test := range tests {
+		dia := RandomDIA(test.s, test.s)
+		tr := mat.Trace(dia)
+		var checkTr float64
+		for i := 0; i < test.s; i++ {
+			checkTr += dia.At(i, i)
+		}
+		if !floats.EqualWithinAbs(tr, checkTr, 1e-13) {
+			t.Logf("trace mismatch: %f vs %f", tr, checkTr)
+			t.Fail()
+		}
+
 	}
 }


### PR DESCRIPTION
add tests for tracer
add benchmarks for trace (which is now much faster)

also added a colnnz() to csc which was part of the trace implementation at one point.  left in as feels like a gap. open to removing if someone has strong views.  not clear why rownnz() would be on csr without colnnz() on csc though.

<table class='benchstat oldnew'>
<tr class='configs'><th><th>/tmp/sparse_old.txt<th>/tmp/sparse_new.txt


<tbody>
<tr><th><th colspan='2' class='metric'>time/op<th>delta
<tr class='better'><td>TraceCS/BenchTraceCS3/0.010000-100-4<td>1.16µs ± 3%<td>0.72µs ± 3%<td class='delta'>−37.76%<td class='note'>(p=0.000 n=10&#43;8)
<tr class='better'><td>TraceCS/BenchTraceCS4/0.010000-100-4<td>1.15µs ± 5%<td>0.70µs ± 3%<td class='delta'>−38.94%<td class='note'>(p=0.000 n=10&#43;10)
<tr class='unchanged'><td>TraceCS/BenchTraceCS3/0.400000-100-4<td>5.28µs ± 1%<td>5.35µs ± 3%<td class='nodelta'>~<td class='note'>(p=0.189 n=9&#43;10)
<tr class='better'><td>TraceCS/BenchTraceCS4/0.400000-100-4<td>5.06µs ± 1%<td>4.85µs ± 5%<td class='delta'>−4.14%<td class='note'>(p=0.005 n=8&#43;9)
<tr class='better'><td>TraceCS/BenchTraceCS3/0.010000-200-4<td>2.45µs ± 2%<td>1.80µs ± 2%<td class='delta'>−26.69%<td class='note'>(p=0.000 n=10&#43;10)
<tr class='better'><td>TraceCS/BenchTraceCS4/0.010000-200-4<td>2.50µs ± 3%<td>1.83µs ± 2%<td class='delta'>−26.81%<td class='note'>(p=0.000 n=9&#43;10)
<tr class='unchanged'><td>TraceCS/BenchTraceCS3/0.400000-200-4<td>16.5µs ± 4%<td>16.2µs ± 3%<td class='nodelta'>~<td class='note'>(p=0.108 n=9&#43;9)
<tr class='better'><td>TraceCS/BenchTraceCS4/0.400000-200-4<td>16.3µs ± 2%<td>16.0µs ± 2%<td class='delta'>−2.17%<td class='note'>(p=0.001 n=8&#43;10)
<tr class='better'><td>TraceCS/BenchTraceCS3/0.010000-400-4<td>6.35µs ± 4%<td>5.57µs ± 7%<td class='delta'>−12.34%<td class='note'>(p=0.000 n=10&#43;10)
<tr class='better'><td>TraceCS/BenchTraceCS4/0.010000-400-4<td>6.71µs ± 6%<td>4.94µs ± 3%<td class='delta'>−26.35%<td class='note'>(p=0.000 n=9&#43;10)
<tr class='unchanged'><td>TraceCS/BenchTraceCS3/0.400000-400-4<td>55.2µs ± 2%<td>56.6µs ± 6%<td class='nodelta'>~<td class='note'>(p=0.278 n=9&#43;10)
<tr class='unchanged'><td>TraceCS/BenchTraceCS4/0.400000-400-4<td>56.0µs ± 2%<td>55.5µs ± 6%<td class='nodelta'>~<td class='note'>(p=0.053 n=10&#43;9)
<tr class='better'><td>TraceCS/BenchTraceCS3/0.010000-800-4<td>22.3µs ± 1%<td>20.9µs ± 7%<td class='delta'>−5.97%<td class='note'>(p=0.003 n=8&#43;10)
<tr class='better'><td>TraceCS/BenchTraceCS4/0.010000-800-4<td>22.7µs ± 2%<td>20.5µs ± 4%<td class='delta'>−9.86%<td class='note'>(p=0.000 n=10&#43;10)
<tr class='better'><td>TraceCS/BenchTraceCS3/0.400000-800-4<td>229µs ± 7%<td>212µs ± 2%<td class='delta'>−7.03%<td class='note'>(p=0.000 n=10&#43;9)
<tr class='better'><td>TraceCS/BenchTraceCS4/0.400000-800-4<td>221µs ± 1%<td>216µs ± 3%<td class='delta'>−2.34%<td class='note'>(p=0.006 n=9&#43;9)
<tr class='better'><td>TraceCS/BenchTraceCS3/0.010000-1600-4<td>63.7µs ± 6%<td>59.2µs ± 4%<td class='delta'>−6.99%<td class='note'>(p=0.000 n=9&#43;10)
<tr class='better'><td>TraceCS/BenchTraceCS4/0.010000-1600-4<td>63.8µs ± 6%<td>57.6µs ± 3%<td class='delta'>−9.76%<td class='note'>(p=0.000 n=10&#43;10)
<tr class='unchanged'><td>TraceCS/BenchTraceCS3/0.400000-1600-4<td>1.00ms ± 9%<td>0.97ms ±10%<td class='nodelta'>~<td class='note'>(p=0.156 n=9&#43;10)
<tr class='unchanged'><td>TraceCS/BenchTraceCS4/0.400000-1600-4<td>952µs ± 3%<td>957µs ± 5%<td class='nodelta'>~<td class='note'>(p=0.529 n=10&#43;10)
<tr class='better'><td>TraceDIA/BenchTraceDIA-100-4<td>657ns ± 3%<td>142ns ± 5%<td class='delta'>−78.43%<td class='note'>(p=0.000 n=8&#43;10)
<tr class='better'><td>TraceDIA/BenchTraceDIA-200-4<td>1.29µs ±14%<td>0.17µs ±18%<td class='delta'>−86.80%<td class='note'>(p=0.000 n=10&#43;10)
<tr class='better'><td>TraceDIA/BenchTraceDIA-400-4<td>2.30µs ± 3%<td>0.20µs ± 3%<td class='delta'>−91.31%<td class='note'>(p=0.000 n=10&#43;10)
<tr class='better'><td>TraceDIA/BenchTraceDIA-800-4<td>4.70µs ± 7%<td>0.28µs ± 3%<td class='delta'>−94.12%<td class='note'>(p=0.000 n=10&#43;10)
<tr class='better'><td>TraceDIA/BenchTraceDIA-1600-4<td>9.06µs ± 8%<td>0.45µs ± 9%<td class='delta'>−95.00%<td class='note'>(p=0.000 n=10&#43;10)
<tr><td>&nbsp;
</tbody>

</table>