### PR TITLE
add MulMatSparseVec function and test

### DIFF
--- a/matrix.go
+++ b/matrix.go
@@ -334,3 +334,33 @@ func MulMatMat(transA bool, alpha float64, a BlasCompatibleSparser, b mat.Matrix
 	putFloats(col)
 	return c
 }
+
+// GenericMulMatMat ...
+func GenericMulMatMat(transA bool, alpha float64, a mat.Matrix, b mat.Matrix, c mat.Matrix) mat.Matrix {
+	aBlasCompat, aIsBlasCompat := a.(BlasCompatibleSparser)
+	bSparseVec, bIsSparseVec := b.(*Vector)
+
+	if aIsBlasCompat {
+		if c == nil {
+			return MulMatMat(transA, alpha, aBlasCompat, b, nil)
+		}
+		if cDense, cIsDense := c.(*mat.Dense); cIsDense {
+			return MulMatMat(transA, alpha, aBlasCompat, b, cDense)
+		}
+		panic(mat.ErrShape)
+	}
+
+	if bIsSparseVec {
+		if transA {
+			panic(mat.ErrShape)
+		}
+		if c == nil {
+			return MulMatSparseVec(alpha, a, bSparseVec, nil)
+		}
+		if cVecDense, cIsVecDense := c.(*mat.VecDense); cIsVecDense {
+			return MulMatSparseVec(alpha, a, bSparseVec, cVecDense)
+		}
+		panic(mat.ErrShape)
+	}
+	panic(mat.ErrShape)
+}

--- a/matrix.go
+++ b/matrix.go
@@ -334,33 +334,3 @@ func MulMatMat(transA bool, alpha float64, a BlasCompatibleSparser, b mat.Matrix
 	putFloats(col)
 	return c
 }
-
-// GenericMulMatMat ...
-func GenericMulMatMat(transA bool, alpha float64, a mat.Matrix, b mat.Matrix, c mat.Matrix) mat.Matrix {
-	aBlasCompat, aIsBlasCompat := a.(BlasCompatibleSparser)
-	bSparseVec, bIsSparseVec := b.(*Vector)
-
-	if aIsBlasCompat {
-		if c == nil {
-			return MulMatMat(transA, alpha, aBlasCompat, b, nil)
-		}
-		if cDense, cIsDense := c.(*mat.Dense); cIsDense {
-			return MulMatMat(transA, alpha, aBlasCompat, b, cDense)
-		}
-		panic(mat.ErrShape)
-	}
-
-	if bIsSparseVec {
-		if transA {
-			panic(mat.ErrShape)
-		}
-		if c == nil {
-			return MulMatSparseVec(alpha, a, bSparseVec, nil)
-		}
-		if cVecDense, cIsVecDense := c.(*mat.VecDense); cIsVecDense {
-			return MulMatSparseVec(alpha, a, bSparseVec, cVecDense)
-		}
-		panic(mat.ErrShape)
-	}
-	panic(mat.ErrShape)
-}

--- a/matrix_test.go
+++ b/matrix_test.go
@@ -294,13 +294,10 @@ func TestMulMatMat(t *testing.T) {
 						transInd = "^T"
 					}
 					var ccopy *mat.Dense
-					var cPrimecopy *mat.Dense
 					if test.c != nil {
 						ccopy = mat.DenseCopyOf(test.c)
-						cPrimecopy = mat.DenseCopyOf(test.c)
 					}
 					c := MulMatMat(transA, test.alpha, amat, b.matrix, ccopy)
-					cPrime := GenericMulMatMat(transA, test.alpha, amat, b.matrix, cPrimecopy)
 
 					cr, cc := c.Dims()
 					if cr != test.er || cc != test.ec {
@@ -313,15 +310,6 @@ func TestMulMatMat(t *testing.T) {
 							e := mat.NewDense(test.er, test.ec, test.eData)
 							t.Errorf("Test %d (%s%s x %s): Failed, expected\n%v\n but received \n%v", ti+1, a.name, transInd, b.name, mat.Formatted(e), mat.Formatted(c))
 							break
-						}
-					}
-					for row := 0; row < cr; row++ {
-						for col := 0; col < cc; col++ {
-							if cPrime.At(row, col) != c.At(row, col) {
-								e := mat.NewDense(test.er, test.ec, test.eData)
-								t.Errorf("Test %d (%s%s x %s): Failed, expected\n%v\n but received \n%v", ti+1, a.name, transInd, b.name, mat.Formatted(e), mat.Formatted(c))
-								break
-							}
 						}
 					}
 				}

--- a/matrix_test.go
+++ b/matrix_test.go
@@ -305,7 +305,6 @@ func TestMulMatMat(t *testing.T) {
 					}
 
 					craw := c.RawMatrix()
-
 					for i, v := range test.eData {
 						if v != craw.Data[i] {
 							e := mat.NewDense(test.er, test.ec, test.eData)

--- a/matrix_test.go
+++ b/matrix_test.go
@@ -294,10 +294,13 @@ func TestMulMatMat(t *testing.T) {
 						transInd = "^T"
 					}
 					var ccopy *mat.Dense
+					var cPrimecopy *mat.Dense
 					if test.c != nil {
 						ccopy = mat.DenseCopyOf(test.c)
+						cPrimecopy = mat.DenseCopyOf(test.c)
 					}
 					c := MulMatMat(transA, test.alpha, amat, b.matrix, ccopy)
+					cPrime := GenericMulMatMat(transA, test.alpha, amat, b.matrix, cPrimecopy)
 
 					cr, cc := c.Dims()
 					if cr != test.er || cc != test.ec {
@@ -310,6 +313,15 @@ func TestMulMatMat(t *testing.T) {
 							e := mat.NewDense(test.er, test.ec, test.eData)
 							t.Errorf("Test %d (%s%s x %s): Failed, expected\n%v\n but received \n%v", ti+1, a.name, transInd, b.name, mat.Formatted(e), mat.Formatted(c))
 							break
+						}
+					}
+					for row := 0; row < cr; row++ {
+						for col := 0; col < cc; col++ {
+							if cPrime.At(row, col) != c.At(row, col) {
+								e := mat.NewDense(test.er, test.ec, test.eData)
+								t.Errorf("Test %d (%s%s x %s): Failed, expected\n%v\n but received \n%v", ti+1, a.name, transInd, b.name, mat.Formatted(e), mat.Formatted(c))
+								break
+							}
 						}
 					}
 				}

--- a/vector_test.go
+++ b/vector_test.go
@@ -497,6 +497,7 @@ func TestMulMatSparseVec(t *testing.T) {
 				}
 				for _, a := range matPair {
 					amat := a.matrix
+					amatCopy := mat.DenseCopyOf(amat)
 					var ycopy *mat.VecDense
 					if test.y != nil {
 						ycopy = mat.VecDenseCopyOf(test.y)
@@ -516,6 +517,9 @@ func TestMulMatSparseVec(t *testing.T) {
 							t.Errorf("Test %d (%s x %s): Failed, expected\n%v\n but received \n%v", ti+1, a.name, b.name, mat.Formatted(e), mat.Formatted(y))
 							break
 						}
+					}
+					if !mat.Equal(amat, amatCopy) {
+						t.Error("somehow matrix changed")
 					}
 				}
 			}


### PR DESCRIPTION
This is an attempt at dense matrix * sparse vector multiplication.  AFAIK there is no standard Sparse BLAS routine for this operation so I've tried to do it in a consistent style.  As for naming: MulMatVec and MulMatMat are taken for the sparse matrix * dense something case.

Maybe it makes more sense to make MulMatVec fully generic and have it delegate to MulMatSparseVec, MulSparseMatVec?  The latter would be a renaming of today's MulMatVec; the new MulMatVec would change BlasCompatibleSparser to mat.Matrix in the signature and contain type assertion logic with no math.  That's a larger change though.