### PR TITLE
Add Vector.Set and Vector.SetVec methods

### DIFF
--- a/vector.go
+++ b/vector.go
@@ -89,10 +89,25 @@ func (v *Vector) AtVec(i int) float64 {
 
 // SetVec sets the i'th element to the value val. It panics if i is out of bounds.
 func (v *Vector) SetVec(i int, val float64) {
+
+	// Panic if the sought index is out of bounds
 	if i < 0 || i >= v.len {
 		panic(mat.ErrRowAccess)
 	}
+
+	// Identify where in the slice this index would exist
 	j := sort.SearchInts(v.ind, i)
+
+	// The value is zero so we are really removing it
+	if val == 0.0 {
+		if j < len(v.ind) && v.ind[j] == i {
+			v.ind = append(v.ind[:j], v.ind[j+1:]...)
+			v.data = append(v.data[:j], v.data[j+1:]...)
+		}
+		return
+	}
+
+	// Set the value
 	if j == len(v.ind) {
 		v.ind = append(v.ind, i)
 		v.data = append(v.data, val)

--- a/vector.go
+++ b/vector.go
@@ -2,9 +2,10 @@ package sparse
 
 import (
 	"math"
+	"sort"
 
-	"github.com/gonum/floats"
 	"github.com/james-bowman/sparse/blas"
+	"gonum.org/v1/gonum/floats"
 	"gonum.org/v1/gonum/mat"
 )
 
@@ -13,6 +14,7 @@ var (
 	_ mat.Matrix  = (*Vector)(nil)
 	_ mat.Vector  = (*Vector)(nil)
 	_ mat.Reseter = (*Vector)(nil)
+	_ mat.Mutable = (*Vector)(nil)
 )
 
 // Vector is a sparse vector format.  It implements the mat.Vector
@@ -54,6 +56,14 @@ func (v *Vector) At(r, c int) float64 {
 	return v.AtVec(r)
 }
 
+// Set sets the element at row r, column c to the value val. Set will panic if c != 0.
+func (v *Vector) Set(r, c int, val float64) {
+	if c != 0 {
+		panic(mat.ErrColAccess)
+	}
+	v.SetVec(r, val)
+}
+
 // T returns the transpose of the receiver.
 func (v *Vector) T() mat.Matrix {
 	return mat.TransposeVec{Vector: v}
@@ -75,6 +85,25 @@ func (v *Vector) AtVec(i int) float64 {
 		}
 	}
 	return 0.0
+}
+
+// SetVec sets the i'th element to the value val. It panics if i is out of bounds.
+func (v *Vector) SetVec(i int, val float64) {
+	if i < 0 || i >= v.len {
+		panic(mat.ErrRowAccess)
+	}
+	j := sort.SearchInts(v.ind, i)
+	if j == len(v.ind) {
+		v.ind = append(v.ind, i)
+		v.data = append(v.data, val)
+	} else if j < len(v.ind) {
+		if v.ind[j] == i {
+			v.data[j] = val
+		} else {
+			v.ind = append(v.ind[:j], append([]int{i}, v.ind[j:]...)...)
+			v.data = append(v.data[:j], append([]float64{val}, v.data[j:]...)...)
+		}
+	}
 }
 
 // Len returns the length of the vector

--- a/vector_test.go
+++ b/vector_test.go
@@ -461,6 +461,24 @@ func TestVectorSetVec(t *testing.T) {
 			source:   NewVector(5, []int{1, 2, 3}, []float64{1.1, 2.2, 3.3}),
 			expected: NewVector(5, []int{1, 2, 3}, []float64{1.1, 8.8, 3.3}),
 		},
+		{
+			idx:      1,
+			val:      0.0,
+			source:   NewVector(5, []int{1, 2, 4}, []float64{1.1, 2.2, 4.4}),
+			expected: NewVector(5, []int{2, 4}, []float64{2.2, 4.4}),
+		},
+		{
+			idx:      2,
+			val:      0.0,
+			source:   NewVector(5, []int{1, 2, 3}, []float64{1.1, 2.2, 3.3}),
+			expected: NewVector(5, []int{1, 3}, []float64{1.1, 3.3}),
+		},
+		{
+			idx:      3,
+			val:      0.0,
+			source:   NewVector(5, []int{1, 2, 3}, []float64{1.1, 2.2, 3.3}),
+			expected: NewVector(5, []int{1, 2}, []float64{1.1, 2.2}),
+		},
 	}
 
 	for ti, test := range tests {

--- a/vector_test.go
+++ b/vector_test.go
@@ -429,3 +429,193 @@ func TestVecToVecDense(t *testing.T) {
 		}
 	}
 }
+
+func TestVectorSetVec(t *testing.T) {
+	tests := []struct {
+		idx      int
+		val      float64
+		source   *Vector
+		expected *Vector
+	}{
+		{
+			idx:      0,
+			val:      0.1,
+			source:   NewVector(5, []int{1, 2, 4}, []float64{1.1, 2.2, 4.4}),
+			expected: NewVector(5, []int{0, 1, 2, 4}, []float64{0.1, 1.1, 2.2, 4.4}),
+		},
+		{
+			idx:      3,
+			val:      3.3,
+			source:   NewVector(5, []int{1, 2, 4}, []float64{1.1, 2.2, 4.4}),
+			expected: NewVector(5, []int{1, 2, 3, 4}, []float64{1.1, 2.2, 3.3, 4.4}),
+		},
+		{
+			idx:      4,
+			val:      4.4,
+			source:   NewVector(5, []int{1, 2, 3}, []float64{1.1, 2.2, 3.3}),
+			expected: NewVector(5, []int{1, 2, 3, 4}, []float64{1.1, 2.2, 3.3, 4.4}),
+		},
+		{
+			idx:      2,
+			val:      8.8,
+			source:   NewVector(5, []int{1, 2, 3}, []float64{1.1, 2.2, 3.3}),
+			expected: NewVector(5, []int{1, 2, 3}, []float64{1.1, 8.8, 3.3}),
+		},
+	}
+
+	for ti, test := range tests {
+		act := new(Vector)
+		act.CloneVec(test.source)
+		act.SetVec(test.idx, test.val)
+
+		if len(test.expected.ind) != len(act.ind) {
+			t.Errorf("Test %d: Incorrect count for indices, Expected %v but received %v", ti+1, len(test.expected.ind), len(act.ind))
+		} else if len(test.expected.data) != len(act.data) {
+			t.Errorf("Test %d: Incorrect count for data, Expected %v but received %v", ti+1, len(test.expected.data), len(act.data))
+		} else {
+			for i := 0; i < len(test.expected.ind); i++ {
+				if test.expected.ind[i] != act.ind[i] {
+					t.Errorf("Test %d: Mismatch indice at index %d, Expected %v but received %v", ti+1, i, test.expected.ind[i], act.ind[i])
+				}
+			}
+			for i := 0; i < len(test.expected.data); i++ {
+				if test.expected.data[i] != act.data[i] {
+					t.Errorf("Test %d: Mismatch data at index %d, Expected %v but received %v", ti+1, i, test.expected.data[i], act.data[i])
+				}
+			}
+		}
+	}
+}
+
+func TestVectorSet(t *testing.T) {
+	tests := []struct {
+		idx      int
+		val      float64
+		source   *Vector
+		expected *Vector
+	}{
+		{
+			idx:      0,
+			val:      0.1,
+			source:   NewVector(5, []int{1, 2, 4}, []float64{1.1, 2.2, 4.4}),
+			expected: NewVector(5, []int{0, 1, 2, 4}, []float64{0.1, 1.1, 2.2, 4.4}),
+		},
+		{
+			idx:      3,
+			val:      3.3,
+			source:   NewVector(5, []int{1, 2, 4}, []float64{1.1, 2.2, 4.4}),
+			expected: NewVector(5, []int{1, 2, 3, 4}, []float64{1.1, 2.2, 3.3, 4.4}),
+		},
+		{
+			idx:      4,
+			val:      4.4,
+			source:   NewVector(5, []int{1, 2, 3}, []float64{1.1, 2.2, 3.3}),
+			expected: NewVector(5, []int{1, 2, 3, 4}, []float64{1.1, 2.2, 3.3, 4.4}),
+		},
+		{
+			idx:      2,
+			val:      8.8,
+			source:   NewVector(5, []int{1, 2, 3}, []float64{1.1, 2.2, 3.3}),
+			expected: NewVector(5, []int{1, 2, 3}, []float64{1.1, 8.8, 3.3}),
+		},
+	}
+
+	for ti, test := range tests {
+		act := new(Vector)
+		act.CloneVec(test.source)
+		act.Set(test.idx, 0, test.val)
+
+		if len(test.expected.ind) != len(act.ind) {
+			t.Errorf("Test %d: Incorrect count for indices, Expected %v but received %v", ti+1, len(test.expected.ind), len(act.ind))
+		} else if len(test.expected.data) != len(act.data) {
+			t.Errorf("Test %d: Incorrect count for data, Expected %v but received %v", ti+1, len(test.expected.data), len(act.data))
+		} else {
+			for i := 0; i < len(test.expected.ind); i++ {
+				if test.expected.ind[i] != act.ind[i] {
+					t.Errorf("Test %d: Mismatch indice at index %d, Expected %v but received %v", ti+1, i, test.expected.ind[i], act.ind[i])
+				}
+			}
+			for i := 0; i < len(test.expected.data); i++ {
+				if test.expected.data[i] != act.data[i] {
+					t.Errorf("Test %d: Mismatch data at index %d, Expected %v but received %v", ti+1, i, test.expected.data[i], act.data[i])
+				}
+			}
+		}
+	}
+}
+
+func TestVecSetVecPanic(t *testing.T) {
+	tests := []struct {
+		idx    int
+		source *Vector
+	}{
+		{
+			idx:    -1,
+			source: NewVector(5, []int{1, 2, 4}, []float64{1.1, 2.2, 4.4}),
+		},
+		{
+			idx:    5,
+			source: NewVector(5, []int{1, 2, 4}, []float64{1.1, 2.2, 4.4}),
+		},
+		{
+			idx:    6,
+			source: NewVector(5, []int{1, 2, 4}, []float64{1.1, 2.2, 4.4}),
+		},
+	}
+
+	for ti, test := range tests {
+		func(ti int, idx int, src *Vector) {
+			defer func() {
+				msg := recover()
+				if msg == nil {
+					t.Errorf("Test %d: method did not panic as epected", ti+1)
+				} else {
+					if msg != mat.ErrRowAccess {
+						t.Errorf("Test %d: recovered error was not mat.ErrRowAccess", ti+1)
+					}
+				}
+			}()
+
+			act := new(Vector)
+			act.CloneVec(test.source)
+			act.SetVec(idx, 1.1)
+
+		}(ti, test.idx, test.source)
+	}
+}
+
+func TestVecSetPanic(t *testing.T) {
+	tests := []struct {
+		col    int
+		source *Vector
+	}{
+		{
+			col:    -1,
+			source: NewVector(5, []int{1, 2, 4}, []float64{1.1, 2.2, 4.4}),
+		},
+		{
+			col:    1,
+			source: NewVector(5, []int{1, 2, 4}, []float64{1.1, 2.2, 4.4}),
+		},
+	}
+
+	for ti, test := range tests {
+		func(ti int, col int, src *Vector) {
+			defer func() {
+				msg := recover()
+				if msg == nil {
+					t.Errorf("Test %d: method did not panic as epected", ti+1)
+				} else {
+					if msg != mat.ErrColAccess {
+						t.Errorf("Test %d: recovered error was not mat.ErrColAccess", ti+1)
+					}
+				}
+			}()
+
+			act := new(Vector)
+			act.CloneVec(test.source)
+			act.Set(2, col, 1.1)
+
+		}(ti, test.col, test.source)
+	}
+}


### PR DESCRIPTION
I needed a version of a sparse vector that that I could update similar to the gonum mat.Dense so I have added Set and SetVec methods to Vector and their accompanying tests. By adding the Set method, Vector also now satisfies the mat.Mutable interface from gonum. Also updated the import in vector.go from "github.com/gonum/floats" to "gonum.org/v1/gonum/floats".

Hopefully this is helpful to project. 