### PR TITLE
sparse cholesky solver

### DIFF
--- a/cholesky.go
+++ b/cholesky.go
@@ -1,0 +1,244 @@
+package sparse
+
+import (
+	"math"
+
+	"github.com/gonum/floats"
+	"gonum.org/v1/gonum/mat"
+)
+
+// Cholesky shadows the gonum mat.Cholesly type
+type Cholesky struct {
+	// internal representation is CSR in lower triangular form
+	chol *CSR
+
+	// some operations use a columnar version
+	cholc *CSC
+	cond  float64
+}
+
+// Dims of the matrix
+func (ch *Cholesky) Dims() (r, c int) {
+	return ch.chol.Dims()
+}
+
+// Symmetric of matrix
+func (ch *Cholesky) Symmetric() int {
+	r, _ := ch.Dims()
+	return r
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+// At from the matrix
+func (ch *Cholesky) At(i, j int) float64 {
+	var val float64
+	ri := ch.chol.RowView(i).(*Vector)
+	rj := ch.chol.RowView(j).(*Vector)
+	// FIXME: check types
+	val = dotSparseSparseNoSortBefore(ri, rj, min(i, j)+1)
+	return val
+}
+
+// T is the same as symmetric
+func (ch *Cholesky) T() mat.Matrix {
+	return ch
+}
+
+func newCSR(r, c int) *CSR {
+	// FIXME: creating a CSR directly leads to panics
+	coo := NewCOO(r, c, nil, nil, nil)
+	return coo.ToCSR()
+}
+
+func newCSC(r, c int) *CSC {
+	// FIXME: creating a CSC directly leads to panics
+	coo := NewCOO(r, c, nil, nil, nil)
+	return coo.ToCSC()
+}
+
+// Det returns the determinant of the factored matrix
+func (ch *Cholesky) Det() float64 {
+	return math.Exp(ch.LogDet())
+}
+
+// LogDet returns ln(determinant) of the factored matrix
+func (ch *Cholesky) LogDet() float64 {
+	det := 0.0
+	for i := 0; i < ch.Symmetric(); i++ {
+		det += 2 * math.Log(ch.chol.At(i, i))
+	}
+	return det
+}
+
+// Factorize a CSR
+// the CSR must be symmetric positive-definite or this won't work
+// FIXME: enforce sym positive definite
+func (ch *Cholesky) Factorize(a *CSR) {
+	r, c := a.Dims()
+	if r != c {
+		panic(mat.ErrShape)
+	}
+	ch.chol = newCSR(r, c)
+	cholCSR(a, ch.chol)
+}
+
+// LTo returns the factored matrix in lower-triangular form as a CSR
+func (ch *Cholesky) LTo(dst *CSR) {
+	r, c := ch.chol.Dims()
+	rDst, cDst := dst.Dims()
+	if r != rDst || c != cDst {
+		panic(mat.ErrShape)
+	}
+	ch.chol.DoNonZero(func(i, j int, v float64) {
+		dst.Set(i, j, v)
+	})
+}
+
+func (ch *Cholesky) buildCholC() {
+	if ch.cholc == nil {
+		r := ch.Symmetric()
+		ch.cholc = newCSC(r, r)
+		ch.chol.DoNonZero(func(i, j int, v float64) {
+			ch.cholc.Set(i, j, v)
+		})
+	}
+}
+
+// SolveVecTo shadows Cholesky.SolveVecTo
+// dst is Dense as this doesn't make any sense with sparse solutions
+func (ch *Cholesky) SolveVecTo(dst *mat.VecDense, b mat.Vector) error {
+	r := ch.Symmetric()
+	dstLen := dst.Len()
+	if r != dstLen {
+		panic(mat.ErrShape)
+	}
+
+	// we are going to need to scan down columns too
+	ch.buildCholC()
+
+	// textbook setup and approach:
+	// Ax=b
+	// LLtx=b
+	// L is ch.Chol
+
+	// forward substitute
+	// Ly=b
+	y := mat.NewVecDense(r, nil)
+	for i := 0; i < r; i++ {
+		denom := ch.chol.At(i, i)
+		k := b.AtVec(i)
+		sum := 0.0
+		ch.chol.DoRowNonZero(i, func(x, z int, v float64) {
+			if z < i {
+				sum += y.AtVec(z) * v
+			}
+		})
+		y.SetVec(i, (k-sum)/denom)
+	}
+
+	// backward substitute
+	// Lt x=y
+	for i := r - 1; i >= 0; i-- {
+		denom := ch.chol.At(i, i)
+		k := y.AtVec(i)
+		sum := 0.0
+		ch.cholc.DoColNonZero(i, func(x, z int, v float64) {
+			if x > i {
+				sum += dst.AtVec(x) * v
+			}
+		})
+		dst.SetVec(i, (k-sum)/denom)
+	}
+
+	return nil
+}
+
+// SolveTo goes column-by-column and applies SolveVecTo
+func (ch *Cholesky) SolveTo(dst *mat.Dense, b mat.Matrix) error {
+	rows, cols := b.Dims()
+	n := ch.Symmetric()
+	if dst.IsEmpty() {
+		dst.ReuseAs(n, cols)
+	}
+	bv, bHasColView := b.(mat.ColViewer)
+	for c := 0; c < cols; c++ {
+		dstView := dst.ColView(c).(*mat.VecDense)
+		if bHasColView {
+			cv := bv.ColView(c)
+			ch.SolveVecTo(dstView, cv)
+		} else {
+			cv := mat.NewVecDense(rows, nil)
+			ch.SolveVecTo(dstView, cv)
+		}
+	}
+	return nil
+}
+
+// basic textbook "dot product" algo, here for comparison against the
+// sparse version
+func cholSimple(matrix mat.Matrix, lower *mat.TriDense) {
+	r, _ := matrix.Dims()
+
+	for i := 0; i < r; i++ {
+		for j := 0; j <= i; j++ {
+			var sum float64
+			if i == j {
+				for k := 0; k < j; k++ {
+					sum += math.Pow(lower.At(j, k), 2)
+				}
+				lower.SetTri(j, j, math.Sqrt(matrix.At(j, j)-sum))
+			} else {
+				for k := 0; k < j; k++ {
+					sum += lower.At(i, k) * lower.At(j, k)
+				}
+				lower.SetTri(i, j, (matrix.At(i, j)-sum)/lower.At(j, j))
+			}
+		}
+	}
+}
+
+// the core sparse factoring algo
+// this is simply the textbook "dot product" algo using a sparse dot
+func cholCSR(matrix *CSR, lower *CSR) {
+	r, _ := matrix.Dims()
+
+	for i := 0; i < r; i++ {
+		if matrix.RowNNZ(i) == 0 {
+			continue
+		}
+		//		rowDotSum := 0.0
+		//		aPos := 0
+		//		bPos := 0
+		//		thisSum := 0.0
+		for j := 0; j <= i; j++ {
+			iRow := lower.RowView(i)
+			iRowS, iRowIsSparse := iRow.(*Vector)
+			jRow := lower.RowView(j)
+			jRowS, jRowIsSparse := jRow.(*Vector)
+			if !iRowIsSparse || !jRowIsSparse {
+				panic(mat.ErrShape)
+			}
+			if i == j {
+				sum := floats.Dot(jRowS.data, jRowS.data)
+				if sum == 0.0 && matrix.At(i, i) == 0.0 {
+					continue
+				}
+				lower.Set(j, j, math.Sqrt(matrix.At(i, i)-sum))
+			} else {
+				//				thisSum, _, _ = dotSparseSparseNoSortBeforeWithStart(iRowS, jRowS, j, aPos, bPos)
+				//				rowDotSum = thisSum
+				rowDotSum := dotSparseSparseNoSort(iRowS, jRowS)
+				if rowDotSum == 0.0 && matrix.At(i, j) == 0.0 {
+					continue
+				}
+				lower.Set(i, j, (matrix.At(i, j)-rowDotSum)/lower.At(j, j))
+			}
+		}
+	}
+}

--- a/cholesky_test.go
+++ b/cholesky_test.go
@@ -1,0 +1,369 @@
+package sparse
+
+import (
+	"fmt"
+	"math"
+	"math/rand"
+	"testing"
+
+	"gonum.org/v1/gonum/mat"
+)
+
+func TestCholesky(t *testing.T) {
+	t.Parallel()
+	for _, test := range []struct {
+		a *mat.SymDense
+
+		cond   float64
+		want   *mat.TriDense
+		posdef bool
+	}{
+		{
+			a: mat.NewSymDense(3, []float64{
+				4, 1, 1,
+				0, 2, 3,
+				0, 0, 6,
+			}),
+			cond: 37,
+			want: mat.NewTriDense(3, true, []float64{
+				2, 0.5, 0.5,
+				0, 1.3228756555322954, 2.0788046015507495,
+				0, 0, 1.195228609334394,
+			}),
+			posdef: true,
+		},
+	} {
+		if !cholMatches(test.a) {
+			t.Error("chol mismatch")
+		}
+	}
+	iters := 16
+	src := rand.NewSource(1)
+	for i := 0; i < iters; i++ {
+		n := 128
+		frac := 0.05
+		m := randomSymDensePosDefinite(n, frac, src)
+		if !cholMatches(m) {
+			t.Error("mismatch on random matrix")
+		}
+	}
+}
+
+func TestCholeskySolveVecTo(t *testing.T) {
+	t.Parallel()
+	for idx, test := range []struct {
+		a   *mat.SymDense
+		b   *mat.VecDense
+		ans *mat.VecDense
+	}{
+		{
+			a: mat.NewSymDense(2, []float64{
+				1, 0,
+				0, 1,
+			}),
+			b:   mat.NewVecDense(2, []float64{5, 6}),
+			ans: mat.NewVecDense(2, []float64{5, 6}),
+		},
+		{
+			a: mat.NewSymDense(3, []float64{
+				53, 59, 37,
+				0, 83, 71,
+				0, 0, 101,
+			}),
+			b:   mat.NewVecDense(3, []float64{5, 6, 7}),
+			ans: mat.NewVecDense(3, []float64{0.20745069393718094, -0.17421475529583694, 0.11577794010226464}),
+		},
+	} {
+		var chol mat.Cholesky
+		ok := chol.Factorize(test.a)
+		if !ok {
+			t.Fatal("unexpected Cholesky factorization failure: not positive definite")
+		}
+
+		var x mat.VecDense
+		err := chol.SolveVecTo(&x, test.b)
+		if err != nil {
+			t.Errorf("unexpected error from Cholesky solve: %v", err)
+		}
+		if !mat.EqualApprox(&x, test.ans, 1e-12) {
+			t.Error("incorrect Cholesky solve solution")
+		}
+
+		var ans mat.VecDense
+		ans.MulVec(test.a, &x)
+		if !mat.EqualApprox(&ans, test.b, 1e-12) {
+			t.Error("incorrect Cholesky solve solution product")
+		}
+
+		//		if !cholMatches(test.a) {
+		//			t.Error("chol mismatch in solvevecto test")
+		//		}
+
+		n := test.a.Symmetric()
+		aCOO := matToCOO(test.a, 1e-10)
+		aCSR := aCOO.ToCSR()
+		var sc Cholesky
+		sc.Factorize(aCSR)
+		xs := mat.NewVecDense(n, nil)
+		sc.SolveVecTo(xs, test.b)
+		if !mat.EqualApprox(xs, test.ans, 1e-12) {
+			t.Error("incorrect sparse Cholesky solution", idx)
+		}
+	}
+}
+
+func TestCholeskyAt(t *testing.T) {
+	t.Parallel()
+	for _, test := range []*mat.SymDense{
+		mat.NewSymDense(3, []float64{
+			53, 59, 37,
+			59, 83, 71,
+			37, 71, 101,
+		}),
+	} {
+		var chol Cholesky
+		csr := matToCSR(test, 1e-8)
+		chol.Factorize(csr)
+		n := test.Symmetric()
+		cn := chol.Symmetric()
+		if cn != n {
+			t.Errorf("Cholesky size does not match. Got %d, want %d", cn, n)
+		}
+		for i := 0; i < n; i++ {
+			for j := 0; j < n; j++ {
+				got := chol.At(i, j)
+				want := test.At(i, j)
+				if math.Abs(got-want) > 1e-12 {
+					t.Errorf("Cholesky at does not match at %d, %d. Got %v, want %v", i, j, got, want)
+				}
+			}
+		}
+	}
+}
+
+func TestCholeskySolveTo(t *testing.T) {
+	t.Parallel()
+	for _, test := range []struct {
+		a   *mat.SymDense
+		b   *mat.Dense
+		ans *mat.Dense
+	}{
+		{
+			a: mat.NewSymDense(2, []float64{
+				1, 0,
+				0, 1,
+			}),
+			b:   mat.NewDense(2, 1, []float64{5, 6}),
+			ans: mat.NewDense(2, 1, []float64{5, 6}),
+		},
+		{
+			a: mat.NewSymDense(3, []float64{
+				53, 59, 37,
+				0, 83, 71,
+				37, 71, 101,
+			}),
+			b:   mat.NewDense(3, 1, []float64{5, 6, 7}),
+			ans: mat.NewDense(3, 1, []float64{0.20745069393718094, -0.17421475529583694, 0.11577794010226464}),
+		},
+	} {
+		var chol Cholesky
+		csr := matToCSR(test.a, 1e-8)
+		chol.Factorize(csr)
+
+		var x mat.Dense
+		err := chol.SolveTo(&x, test.b)
+		if err != nil {
+			t.Errorf("unexpected error from Cholesky solve: %v", err)
+		}
+		if !mat.EqualApprox(&x, test.ans, 1e-12) {
+			t.Error("incorrect Cholesky solve solution")
+		}
+
+		var ans mat.Dense
+		ans.Mul(test.a, &x)
+		if !mat.EqualApprox(&ans, test.b, 1e-12) {
+			t.Error("incorrect Cholesky solve solution product")
+		}
+	}
+}
+
+func cholMatches(a *mat.SymDense) bool {
+	_, n := a.Dims()
+	var chol mat.Cholesky
+
+	ok := chol.Factorize(a)
+	if !ok {
+		fmt.Println("cannot factorize")
+		return false
+	}
+	var L mat.TriDense
+	chol.LTo(&L)
+	simpleRes := mat.NewTriDense(n, false, nil)
+	cholSimple(a, simpleRes)
+	if !mat.EqualApprox(&L, simpleRes, 1e-10) {
+		return false
+	}
+	coo := NewCOO(n, n, nil, nil, nil)
+	csrRes := coo.ToCSR()
+	aCOO := matToCOO(a, 1e-10)
+	aCSR := aCOO.ToCSR()
+	cholCSR(aCSR, csrRes)
+	if !mat.EqualApprox(&L, csrRes, 1e-10) {
+		for i := 0; i < n; i++ {
+			for j := 0; j < n; j++ {
+				fmt.Println(L.At(i, j), csrRes.At(i, j))
+			}
+		}
+		return false
+	}
+
+	return true
+}
+
+// computes a permutation matrix where each non-zero is rand.Float64() instead of 1
+// and then return aat of that
+func randomScaledPermutationMatrixAAT(n int, src rand.Source) *mat.SymDense {
+	idxList := make([]int, n)
+	for i := range idxList {
+		idxList[i] = i
+	}
+	rnd := rand.New(src)
+	rnd.Shuffle(n, func(i, j int) { idxList[i], idxList[j] = idxList[j], idxList[i] })
+	m := mat.NewDense(n, n, nil)
+
+	for i, j := range idxList {
+		v := rnd.Float64()
+		m.Set(i, j, v)
+	}
+	mt := m.T()
+	mmt := mat.NewDense(n, n, nil)
+	mmt.Mul(m, mt)
+	mmtSym := mat.NewSymDense(n, mmt.RawMatrix().Data)
+	return mmtSym
+}
+
+func randomSymDensePosDefinite(n int, fracNZ float64, src rand.Source) *mat.SymDense {
+	ok := false
+	for !ok {
+		m := randomSymDensePosDefiniteInternal(n, fracNZ, src)
+		var chol mat.Cholesky
+		ok = chol.Factorize(m)
+		if ok {
+			return m
+		}
+	}
+	return nil
+}
+
+func randomSymDensePosDefiniteInternal(n int, fracNZ float64, src rand.Source) *mat.SymDense {
+	rnd := rand.New(src)
+	m := mat.NewDense(n, n, nil)
+	nnz := int(float64(n) * float64(n) * fracNZ)
+	rList := make([]int, nnz)
+	cList := make([]int, nnz)
+	for i := range rList {
+		rList[i] = rnd.Intn(n)
+		cList[i] = rnd.Intn(n)
+	}
+	for i := range rList {
+		r := rList[i]
+		c := cList[i]
+		m.Set(r, c, rnd.Float64())
+		m.Set(c, r, rnd.Float64())
+	}
+	mt := m.T()
+	mmt := mat.NewDense(n, n, nil)
+	mmt.Mul(m, mt)
+	mmtSym := mat.NewSymDense(n, mmt.RawMatrix().Data)
+	return mmtSym
+}
+
+func matToCOO(m mat.Matrix, tol float64) *COO {
+	r, c := m.Dims()
+	newMat := NewCOO(r, c, nil, nil, nil)
+	for i := 0; i < r; i++ {
+		for j := 0; j < c; j++ {
+			v := m.At(i, j)
+			if v > tol || v < -tol {
+				newMat.Set(i, j, v)
+			}
+		}
+	}
+	//	nSize := float64(r * c)
+	//	nnz := float64(newMat.NNZ())
+	//	ratio := nnz / nSize
+	//	fmt.Println("frac=", ratio)
+	return newMat
+}
+
+func matToCSR(m mat.Matrix, tol float64) *CSR {
+	coo := matToCOO(m, tol)
+	return coo.ToCSR()
+}
+
+func BenchmarkCholSimple800(b *testing.B) { cholSimpleBench(b, 400, 0) }
+
+func BenchmarkCholGoNum400S3(b *testing.B) { cholGoNumBench(b, 400, 3.0/400) }
+func BenchmarkCholGoNum400S5(b *testing.B) { cholGoNumBench(b, 400, 5.0/400) }
+func BenchmarkCholGoNum400S7(b *testing.B) { cholGoNumBench(b, 400, 7.0/400) }
+func BenchmarkCholGoNum400S9(b *testing.B) { cholGoNumBench(b, 400, 9.0/400) }
+func BenchmarkCholGoNum400(b *testing.B)   { cholGoNumBench(b, 400, 0.0) }
+func BenchmarkCholGoNum800(b *testing.B)   { cholGoNumBench(b, 800, 0.0) }
+func BenchmarkCholGoNum1600(b *testing.B)  { cholGoNumBench(b, 1600, 0.0) }
+func BenchmarkCholGoNum3200(b *testing.B)  { cholGoNumBench(b, 3200, 0.0) }
+func BenchmarkCholGoNum6400(b *testing.B)  { cholGoNumBench(b, 6400, 0.0) }
+
+//func BenchmarkCholGoNum12800(b *testing.B) { cholGoNumBench(b, 12800, 0.0) }
+
+func BenchmarkCholSparse400S3(b *testing.B) { sparseCholBench(b, 400, 3.0/400) }
+func BenchmarkCholSparse400S5(b *testing.B) { sparseCholBench(b, 400, 5.0/400) }
+func BenchmarkCholSparse400S7(b *testing.B) { sparseCholBench(b, 400, 7.0/400) }
+func BenchmarkCholSparse400S9(b *testing.B) { sparseCholBench(b, 400, 9.0/400) }
+func BenchmarkCholSparse400(b *testing.B)   { sparseCholBench(b, 400, 0.0) }
+func BenchmarkCholSparse800(b *testing.B)   { sparseCholBench(b, 800, 0.0) }
+func BenchmarkCholSparse1600(b *testing.B)  { sparseCholBench(b, 1600, 0.0) }
+func BenchmarkCholSparse3200(b *testing.B)  { sparseCholBench(b, 3200, 0.0) }
+func BenchmarkCholSparse6400(b *testing.B)  { sparseCholBench(b, 6400, 0.0) }
+
+//func BenchmarkCholSparse12800(b *testing.B) { sparseCholBench(b, 12800, 0.0) }
+
+func cholGoNumBench(b *testing.B, size int, frac float64) {
+	src := rand.NewSource(1)
+	m := randomScaledPermutationMatrixAAT(size, src)
+	if frac != 0.0 {
+		m = randomSymDensePosDefinite(size, frac, src)
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		var chol mat.Cholesky
+		chol.Factorize(m)
+	}
+}
+
+func cholSimpleBench(b *testing.B, size int, frac float64) {
+	src := rand.NewSource(1)
+	m := randomScaledPermutationMatrixAAT(size, src)
+	if frac != 0.0 {
+		m = randomSymDensePosDefinite(size, frac, src)
+	}
+	simpleRes := mat.NewTriDense(size, false, nil)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		cholSimple(m, simpleRes)
+	}
+}
+
+func sparseCholBench(b *testing.B, size int, frac float64) {
+	src := rand.NewSource(1)
+	mDense := randomScaledPermutationMatrixAAT(size, src)
+	if frac != 0.0 {
+		mDense = randomSymDensePosDefinite(size, frac, src)
+	}
+	coo := NewCOO(size, size, nil, nil, nil)
+	csrRes := coo.ToCSR()
+	aCSR := matToCSR(mDense, 1e-8)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		cholCSR(aCSR, csrRes)
+	}
+}

--- a/vector.go
+++ b/vector.go
@@ -560,12 +560,28 @@ func (v *Vector) IsSorted() bool {
 func dotSparseSparse(a, b *Vector) float64 {
 	a.Sort()
 	b.Sort()
+	return dotSparseSparseNoSort(a, b)
+}
+
+func dotSparseSparseNoSort(a, b *Vector) float64 {
+	n := a.Len()
+	return dotSparseSparseNoSortBefore(a, b, n)
+}
+
+func dotSparseSparseNoSortBefore(a, b *Vector, n int) float64 {
+	v, _, _ := dotSparseSparseNoSortBeforeWithStart(a, b, n, 0, 0)
+	return v
+}
+
+func dotSparseSparseNoSortBeforeWithStart(a, b *Vector, n, aStart, bStart int) (float64, int, int) {
 	tot := 0.0
-	aPos := 0
-	bPos := 0
-	for aPos < len(a.ind) && bPos < len(b.ind) {
-		aIndex := a.ind[aPos]
-		bIndex := b.ind[bPos]
+	aPos := aStart
+	bPos := bStart
+	aIndex := -1
+	bIndex := -1
+	for aPos < len(a.ind) && bPos < len(b.ind) && aIndex < n && bIndex < n {
+		aIndex = a.ind[aPos]
+		bIndex = b.ind[bPos]
 		if aIndex == bIndex {
 			tot += a.data[aPos] * b.data[bPos]
 			aPos++
@@ -578,5 +594,5 @@ func dotSparseSparse(a, b *Vector) float64 {
 			}
 		}
 	}
-	return tot
+	return tot, aPos, bPos
 }


### PR DESCRIPTION
this is an attempt at a sparse cholesky implementation.  i've taken parts of the interface from gonum.mat.Cholesky but not all.  curious your thoughts on how to organize this.

many of the methods on mat.Cholesky are not associated with interfaces.  so it feels safe to just implement what's needed as-needed.  i expect designing this well will lead to a proposal to add a mat.Solver/Factorizer interface into gonum. Or something like that.

some of mat.Cholesky's methods don't feel useful here, at least not on their own.  the symmetric stuff might make sense if associated with sparse.SymCSR etc.  somewhat similar for inverse.

i'm stopping well short of implementing cholmod in the same manner this package implements sparseblas because a) it's a v large piece of work i don't really need it and b) memory savings >>  improved performance here.