### PR TITLE
Fix leading duplicates in COO.

### DIFF
--- a/coordinate.go
+++ b/coordinate.go
@@ -186,15 +186,19 @@ func compress(row []int, col []int, data []float64, n int) (ia []int, ja []int, 
 }
 
 func dedupe(ia []int, ja []int, d []float64, m int, n int) ([]int, []float64) {
-	//w := make([]int, n)
-	w := getInts(n, true)
+	w := getInts(n, false)
 	defer putInts(w)
-	nz := 0
 
+	// start -1 to dedupe leading duplicates
+	for k, _ := range w {
+		w[k] = -1
+	}
+
+	nz := 0
 	for i := 0; i < m; i++ {
 		q := nz
 		for j := ia[i]; j < ia[i+1]; j++ {
-			if w[ja[j]] > q {
+			if w[ja[j]] >= q {
 				d[w[ja[j]]] += d[j]
 			} else {
 				w[ja[j]] = nz

--- a/coordinate_test.go
+++ b/coordinate_test.go
@@ -7,6 +7,24 @@ import (
 	"gonum.org/v1/gonum/mat"
 )
 
+func CreateCOOWithLeadingDupes(m, n int, data []float64) mat.Matrix {
+	pad := 0
+	I, J, V := make([]int, pad), make([]int, pad), make([]float64, pad)
+	coo := NewCOO(m, n, I, J, V)
+
+	// insert leading duplicates
+	coo.Set(0, 0, 100)
+	coo.Set(0, 0, -100)
+
+	// insert matrix
+	for i := 0; i < m; i++ {
+		for j := 0; j < n; j++ {
+			coo.Set(i, j, data[i*n+j])
+		}
+	}
+	return coo
+}
+
 func CreateCOOWithDupes(m, n int, data []float64) mat.Matrix {
 	coo := CreateCOO(m, n, data).(*COO)
 	for k := 0; k < rand.Intn(m*n-1)+1; k++ {
@@ -44,6 +62,11 @@ func TestCOOConversion(t *testing.T) {
 		{
 			"COO -> CSR (With Dupes)",
 			CreateCOOWithDupes,
+			func(a TypeConverter) Sparser { return a.ToCSR() },
+		},
+		{
+			"COO -> CSR (With Leading Dupes)",
+			CreateCOOWithLeadingDupes,
 			func(a TypeConverter) Sparser { return a.ToCSR() },
 		},
 		{


### PR DESCRIPTION
When leading duplicates are present in a COO matrix, the conversion
towards CSR becomes invalid and not identical to the original COO
representation. This changes the dedupe function, such that leading
duplicates are treated correctly by starting the counter at -1 compared
to 0.

The following illustrates the problem: 
``` 
// create identity matrix with a duplicate at (0,0) that should drop out
coo := NewCOO(2, 2, make([]int, 0), make([]int, 0), make([]float64, 0))
coo.Set(0, 0, 100)
coo.Set(0, 0, -100)
coo.Set(0, 0, 1)	
coo.Set(1, 1, 1)

csr := coo.ToCSR()

// compare matrices after conversion to CSR, expect equal matrices. 
if !mat.Equal(coo, csr) {
    fmt.Printf("Expected:\n%v\n but created:\n%v\n", mat.Formatted(coo), mat.Formatted(csr))
}
```

When evaluated, we observe the output, showing the influence of the leading duplicates. 
```
⎡1  0⎤
⎣0  1⎦
but created:
⎡100    0⎤
⎣  0    1⎦
```
The committed change should resolve this. 
